### PR TITLE
Rename bootstrap command

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -11,7 +11,7 @@ const { BABEL_CONFIGS } = babel;
 // eslint-disable-next-line
 yargs
   .command(
-    'bootstrap-config',
+    'bootstrap',
     'Set up custom configurations for babel, eslint, prettier, etc.',
     yrgs =>
       yrgs


### PR DESCRIPTION
The README lists the bootstrap command as `foundry bootstrap`, not `foundry bootstrap-config`. I prefer the shorter version, so I've updated code.