### PR TITLE
Enable experimental feature support for eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-config-prettier": "^2.9.0",
+    "eslint-plugin-babel": "^5.1.0",
     "eslint-plugin-import": "^2.12.0",
     "eslint-plugin-jest": "^21.17.0",
     "eslint-plugin-prettier": "^2.6.0",

--- a/src/configs/eslint.js
+++ b/src/configs/eslint.js
@@ -8,7 +8,7 @@ export const overwritePresets = merge({
 
 export const base = {
   extends: ['airbnb-base', 'prettier', 'plugin:jest/recommended'],
-  plugins: ['prettier', 'jest'],
+  plugins: ['babel', 'prettier', 'jest'],
   rules: {
     'no-use-before-define': ['error', { functions: false }],
     'no-underscore-dangle': 'off',
@@ -23,6 +23,9 @@ export const base = {
       }
     ],
     // TODO: can you remove these when you have a config?
+    'babel/object-curly-spacing': 1,
+    'babel/quotes': 1,
+    'babel/semi': 1,
     'prettier/prettier': [
       'error',
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1969,6 +1969,12 @@ eslint-module-utils@^2.2.0:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
 
+eslint-plugin-babel@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-babel/-/eslint-plugin-babel-5.1.0.tgz#9c76e476162041e50b6ba69aa4eae3bdd6a4e1c3"
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
 eslint-plugin-import@^2.12.0:
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.12.0.tgz#dad31781292d6664b25317fd049d2e2b2f02205d"
@@ -2007,6 +2013,10 @@ eslint-plugin-react@^7.8.2:
 eslint-restricted-globals@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz#35f0d5cbc64c2e3ed62e93b4b1a7af05ba7ed4d7"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
 
 eslint-scope@^3.7.1, eslint-scope@~3.7.1:
   version "3.7.1"


### PR DESCRIPTION
## Changes

* Install and configure [`eslint-plugin-babel`](https://github.com/babel/eslint-plugin-babel)
* Stops `eslint` from failing at class properties, JSX fragment shorthand syntax, and the new `export ... from '...'` syntax

> An `eslint` plugin companion to `babel-eslint`. `babel-eslint` does a great job at adapting `eslint` for use with Babel, but it can't change the built-in rules to support experimental features. `eslint-plugin-babel` re-implements problematic rules so they do not give false positives or negatives.