### PR TITLE
Deprecate eslint rule jsx-a11y/label-has-for

### DIFF
--- a/src/configs/eslint.js
+++ b/src/configs/eslint.js
@@ -31,16 +31,6 @@ export const base = {
       {
         devDependencies: ['*.js', '**/*.story.js', '**/*.spec.js']
       }
-    ],
-    'jsx-a11y/label-has-for': [
-      2,
-      {
-        components: ['Label'],
-        required: {
-          some: ['nesting', 'id']
-        },
-        allowChildren: true
-      }
     ]
   },
   globals: {


### PR DESCRIPTION
Deprecated in [eslint-plugin-jsx-a11y@6.1.0](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md).