### PR TITLE
Ignore devDependencies in config files

### DIFF
--- a/src/configs/eslint.js
+++ b/src/configs/eslint.js
@@ -69,6 +69,17 @@ export const base = {
       env: {
         'jest/globals': true
       }
+    },
+    {
+      files: ['*.config.js', '.*rc.js'],
+      rules: {
+        'import/no-extraneous-dependencies': [
+          'error',
+          {
+            devDependencies: true
+          }
+        ]
+      }
     }
   ]
 };


### PR DESCRIPTION
# Purpose

The bootstrapped config files import from `@sumup/foundry`, usually listed as a `devDependency`. `eslint` incorrectly complains about this. 

## Approach and changes

This PR configures the `import/no-extraneous-dependencies` rule to ignore `devDependency` in the bootstrapped config files.