### PR TITLE
Add plugin for react hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-react-hooks": "^1.2.0",
     "husky": "^1.2.0",
     "jest": "^23.6.0",
     "jest-extended": "^0.11.0",

--- a/src/configs/eslint.js
+++ b/src/configs/eslint.js
@@ -95,8 +95,10 @@ export const react = overwritePresets(base, {
     'plugin:prettier/recommended',
     'prettier/react'
   ],
-  plugins: ['react', 'jsx-a11y'],
+  plugins: ['react', 'react-hooks', 'jsx-a11y'],
   rules: {
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warning',
     'import/no-extraneous-dependencies': [
       'error',
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2147,6 +2147,11 @@ eslint-plugin-prettier@^3.0.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-react-hooks@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.2.0.tgz#a1c78e792b8d7d3e9c2a2aad28df80b9b5cd1101"
+  integrity sha512-pb/pwyHg0K3Ss/8loSwCGRSXIsvPBHWfzcP/6jeei0SgWBOyXRbcKFpGxolg0xSmph0jQKLyM27B74clbZM/YQ==
+
 eslint-plugin-react@^7.11.1:
   version "7.11.1"
   resolved "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz#c01a7af6f17519457d6116aa94fc6d2ccad5443c"


### PR DESCRIPTION
## Purpose

We're about to upgrade to React 16.8.2 on the website with support for hooks. Facebook released [`eslint-plugin-react-hooks`](https://github.com/facebook/react/tree/master/packages/eslint-plugin-react-hooks) which lints for common mistakes when using hooks.

## Changes

- Install `eslint-plugin-react-hooks` and add it to the react eslint configuration