### PR TITLE
Fix eslint hook config

### DIFF
--- a/src/configs/eslint.js
+++ b/src/configs/eslint.js
@@ -98,7 +98,7 @@ export const react = overwritePresets(base, {
   plugins: ['react', 'react-hooks', 'jsx-a11y'],
   rules: {
     'react-hooks/rules-of-hooks': 'error',
-    'react-hooks/exhaustive-deps': 'warning',
+    'react-hooks/exhaustive-deps': 'warn',
     'import/no-extraneous-dependencies': [
       'error',
       {


### PR DESCRIPTION
Hey, 
`react-hooks/exhaustive-deps` expects `warn` instead of `warning`  
