### PR TITLE
feat(eslint): Add emotion plugin for eslint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 __reports__
+junit.xml
 node_modules/
 .npm
 .eslintcache

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-config-prettier": "^3.3.0",
     "eslint-plugin-cypress": "^2.2.1",
+    "eslint-plugin-emotion": "^10.0.7",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jest": "^22.0.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",

--- a/src/configs/eslint.js
+++ b/src/configs/eslint.js
@@ -96,10 +96,15 @@ export const react = overwritePresets(base, {
     'plugin:prettier/recommended',
     'prettier/react'
   ],
-  plugins: ['react', 'react-hooks', 'jsx-a11y'],
+  plugins: ['react', 'react-hooks', 'jsx-a11y', 'emotion'],
   rules: {
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn',
+    'emotion/jsx-import': 'error',
+    'emotion/no-vanilla': 'error',
+    'emotion/import-from-emotion': 'error',
+    'emotion/styled-import': 'error',
+    'emotion/syntax-preference': [2, 'string'],
     'import/no-extraneous-dependencies': [
       'error',
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2112,6 +2112,11 @@ eslint-plugin-cypress@^2.2.1:
   dependencies:
     globals "^11.0.1"
 
+eslint-plugin-emotion@^10.0.7:
+  version "10.0.7"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-emotion/-/eslint-plugin-emotion-10.0.7.tgz#e14d54a2f23c9701d66851a87a5eb35adb10c2a7"
+  integrity sha512-4uasPp7SDt/iYnu+icSq1ZTjGSnk4ZTrHSGXCE790gUfGFZ+Br/VpUfklb5oHeSFVUoRjoTulaEbIrp2Mfo3vA==
+
 eslint-plugin-import@^2.14.0:
   version "2.14.0"
   resolved "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz#6b17626d2e3e6ad52cfce8807a845d15e22111a8"


### PR DESCRIPTION
This PR adds the `emotion` plugin and rules to the `react` config for Eslint to make the [migration to Emotion 10](https://emotion.sh/docs/migrating-to-emotion-10) easier with automatic [codemods](https://emotion.sh/docs/eslint-plugin-emotion#emotion-10-codemods).