### PR TITLE
feat(ci): add CI preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-Foundry uses [`semantic-release`](https://github.com/semantic-release/semantic-release) to automatically publish [GitHub release notes](https://github.comsumup-oss/foundry/releases) for each version.
+Foundry uses [`semantic-release`](https://github.com/semantic-release/semantic-release) to automatically publish [GitHub release notes](https://github.com/sumup-oss/foundry/releases) for each version.

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ module.exports = require('@sumup/foundry/plop')({
 });
 ```
 
-To see which variables are available for use in a Handlebars template, have a look at the [default templates](https://github.comsumup-oss/foundry/tree/master/src/configs/plop/templates).
+To see which variables are available for use in a Handlebars template, have a look at the [default templates](https://github.com/sumup-oss/foundry/tree/master/src/configs/plop/templates).
 
 ## Running a tool
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-react": "^7.0.0",
     "eslint-plugin-react-hooks": "^2.0.0",
+    "handlebars": "^4.7.3",
     "husky": "^3.0.0",
     "inquirer": "^7.0.1",
     "lint-staged": "^10.0.0-beta",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0-semantically-released",
   "description": "A toolkit for JavaScript + TypeScript applications by SumUp.",
   "main": "index.js",
-  "repository": "github:sumup-oss/foundry",
+  "repository": "https://github.com/github:sumup-oss/foundry",
   "author": "Felix Jung <felix.jung@sumup.com>, Connor Bär <connor.baer@sumup.com>",
   "license": "Apache-2.0",
   "bin": "cli/index.js",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0-semantically-released",
   "description": "A toolkit for JavaScript + TypeScript applications by SumUp.",
   "main": "index.js",
-  "repository": "https://github.com/github:sumup-oss/foundry",
+  "repository": "https://github.com/sumup-oss/foundry",
   "author": "Felix Jung <felix.jung@sumup.com>, Connor Bär <connor.baer@sumup.com>",
   "license": "Apache-2.0",
   "bin": "cli/index.js",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -68,6 +68,11 @@ yargs
           desc: 'The directory to write configs to',
           type: 'string',
           default: '.',
+        })
+        .option('overwrite', {
+          desc: 'Whether to overwrite existing config files',
+          type: 'boolean',
+          default: false,
         }),
     (args: InitParams) => execute('init', args),
   )

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -27,6 +27,7 @@ import {
   Language,
   Environment,
   Framework,
+  CI,
   Tool,
   ToolOptions,
   File,
@@ -51,6 +52,7 @@ export interface InitParams {
   environments?: Environment[];
   frameworks?: Framework[];
   openSource?: boolean;
+  ci?: CI;
   overwrite?: boolean;
   publish?: boolean;
   $0?: string;
@@ -92,6 +94,13 @@ export async function init(args: InitParams): Promise<void> {
       message: 'Which framework(s) does the project use?',
       choices: enumToChoices(Framework),
       when: (): boolean => !args.frameworks,
+    },
+    [Prompt.CI]: {
+      type: 'checkbox',
+      name: 'ci',
+      message: 'Which CI platform would you like to use?',
+      choices: enumToChoices(CI),
+      when: (): boolean => isEmpty(args.ci),
     },
     [Prompt.PUBLISH]: {
       type: 'confirm',

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -51,6 +51,7 @@ export interface InitParams {
   environments?: Environment[];
   frameworks?: Framework[];
   openSource?: boolean;
+  overwrite?: boolean;
   publish?: boolean;
   $0?: string;
   _?: string[];
@@ -130,7 +131,12 @@ export async function init(args: InitParams): Promise<void> {
           files.map((file) => ({
             title: `Write "${file.name}"`,
             task: (ctx: never, task): Promise<void> =>
-              writeFile(options.configDir, file.name, file.content).catch(() =>
+              writeFile(
+                options.configDir,
+                file.name,
+                file.content,
+                options.overwrite,
+              ).catch(() =>
                 listrInquirer(
                   [
                     {
@@ -177,7 +183,12 @@ export async function init(args: InitParams): Promise<void> {
               task: ListrTaskWrapper<Context>,
             ): undefined | Promise<void> => {
               try {
-                addPackageScript(ctx.packageJson, name, command);
+                addPackageScript(
+                  ctx.packageJson,
+                  name,
+                  command,
+                  options.overwrite,
+                );
                 return undefined;
               } catch (error) {
                 return listrInquirer(
@@ -228,7 +239,7 @@ export async function init(args: InitParams): Promise<void> {
 
 export function mergeOptions(
   args: InitParams,
-  answers: Omit<Options, 'configDir'>,
+  answers: Omit<Options, 'configDir' | 'overwrite'>,
 ): Options {
   const { $0, _, ...rest } = args;
   return { ...rest, ...answers };

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -81,6 +81,11 @@ async function resolveBinaryPath(
     // from the name of the package.
     const packageJsonPath = await getPackageJsonPath(name, useRelative);
     const { bin: packageBin } = await loadJson(packageJsonPath);
+
+    if (!packageBin) {
+      return null;
+    }
+
     const binaryPath = isString(packageBin) ? packageBin : packageBin[name];
 
     if (!binaryPath) {

--- a/src/configs/ci/github-actions.ts
+++ b/src/configs/ci/github-actions.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2020, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable no-useless-escape */
+
+export const fileName = '.github/workflows/ci.yaml';
+
+export const template = `
+name: Continous Integration
+
+on: [push]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Use Node.js v10
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: $\\{{ runner.OS }}-node-$\\{{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            $\\{{ runner.OS }}-node-$\\{{ env.cache-name }}-
+            $\\{{ runner.OS }}-node-
+            $\\{{ runner.OS }}-
+      - name: Install dependencies
+        run: |
+          npm install -g yarn
+          yarn --pure-lockfile
+{{#includes presets "lint"}}
+      - name: Lint
+        run: yarn lint:ci
+{{/includes}}
+      - name: Upload code coverage
+        uses: codecov/codecov-action@v1.0.3
+        with:
+          token: $\\{{ secrets.CODECOV_TOKEN }}
+{{#includes presets "release"}}
+      - name: Release
+        env:
+          GITHUB_TOKEN: $\\{{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: $\\{{ secrets.NPM_TOKEN }}
+        run: yarn release
+{{/includes}}
+`;

--- a/src/configs/ci/index.ts
+++ b/src/configs/ci/index.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2020, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { includes } from 'lodash/fp';
+import Handlebars from 'handlebars';
+
+import { Options, File, CI } from '../../types/shared';
+
+import * as githubActions from './github-actions';
+
+// eslint-disable-next-line no-confusing-arrow
+Handlebars.registerHelper('includes', (array, value, options) =>
+  includes(value, array) ? options.fn(options.data.root) : null,
+);
+
+const PLATFORM_MAP = {
+  [CI.GITHUB_ACTIONS]: githubActions,
+};
+
+export const files = (options: Options): File[] => {
+  const { ci = CI.GITHUB_ACTIONS } = options;
+  const platform = PLATFORM_MAP[ci];
+  const template = Handlebars.compile(platform.template);
+  const content = template(options);
+  return [
+    {
+      name: platform.fileName,
+      content,
+    },
+  ];
+};

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -21,6 +21,7 @@ import * as lintStaged from './lint-staged';
 import * as plop from './plop';
 import * as prettier from './prettier';
 import * as semanticRelease from './semantic-release';
+import * as ci from './ci';
 
 export const tools: { [key in Tool]?: ToolOptions } = {
   [Tool.ESLINT]: eslint,
@@ -29,4 +30,5 @@ export const tools: { [key in Tool]?: ToolOptions } = {
   [Tool.PLOP]: plop,
   [Tool.PRETTIER]: prettier,
   [Tool.SEMANTIC_RELEASE]: semanticRelease,
+  [Tool.CI]: ci,
 };

--- a/src/lib/files.spec.ts
+++ b/src/lib/files.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2020, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+
+import { writeFile, addPackageScript } from './files';
+
+jest.mock('fs', () => ({
+  writeFile: jest.fn(),
+  mkdirSync: jest.fn(),
+  existsSync: jest.fn(),
+}));
+
+const content = `module.exports = "Hello world"`;
+
+const formattedContent = `module.exports = 'Hello world';
+`;
+
+describe('files', () => {
+  describe('writeFile', () => {
+    it('should create the target folder if it does not exist', () => {
+      const configDir = './config';
+      const filename = '.eslintrc.js';
+      const shouldOverwrite = false;
+
+      writeFile(configDir, filename, content, shouldOverwrite);
+
+      expect(fs.mkdirSync).toHaveBeenCalledWith('config', { recursive: true });
+    });
+
+    it('should write the file to disk', () => {
+      const configDir = './config';
+      const filename = '.eslintrc.js';
+      const shouldOverwrite = false;
+
+      writeFile(configDir, filename, content, shouldOverwrite);
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        'config/.eslintrc.js',
+        expect.any(String),
+        { flag: 'wx' },
+        expect.any(Function),
+      );
+    });
+
+    it('should overwrite the file if it already exists', () => {
+      const configDir = '.';
+      const filename = '.eslintrc.js';
+      const shouldOverwrite = true;
+
+      writeFile(configDir, filename, content, shouldOverwrite);
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        '.eslintrc.js',
+        expect.any(String),
+        { flag: 'w' },
+        expect.any(Function),
+      );
+    });
+
+    it('should format the file contents', () => {
+      const configDir = '.';
+      const filename = '.eslintrc.js';
+      const shouldOverwrite = true;
+
+      writeFile(configDir, filename, content, shouldOverwrite);
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        expect.any(String),
+        formattedContent,
+        expect.any(Object),
+        expect.any(Function),
+      );
+    });
+  });
+
+  describe('addPackageScript', () => {
+    it('should add a script to the package.json file', () => {
+      const packageJson = { scripts: {} };
+      const name = 'lint';
+      const command = 'foundry run eslint src';
+      const shouldOverwrite = false;
+
+      const actual = addPackageScript(
+        packageJson,
+        name,
+        command,
+        shouldOverwrite,
+      );
+
+      const expected = {
+        scripts: { lint: 'foundry run eslint src' },
+      };
+      expect(actual).toEqual(expected);
+    });
+
+    it('should throw an error if a conflicting script exists', () => {
+      const packageJson = { scripts: { lint: 'eslint .' } };
+      const name = 'lint';
+      const command = 'foundry run eslint src';
+      const shouldOverwrite = false;
+
+      const actual = () =>
+        addPackageScript(packageJson, name, command, shouldOverwrite);
+
+      expect(actual).toThrowError();
+    });
+
+    it('should overwrite the conflicting script', () => {
+      const packageJson = { scripts: { lint: 'eslint .' } };
+      const name = 'lint';
+      const command = 'foundry run eslint src';
+      const shouldOverwrite = true;
+
+      const actual = addPackageScript(
+        packageJson,
+        name,
+        command,
+        shouldOverwrite,
+      );
+
+      const expected = {
+        scripts: { lint: 'foundry run eslint src' },
+      };
+      expect(actual).toEqual(expected);
+    });
+  });
+});

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -41,10 +41,9 @@ export function writeFile(
     ? CONFIG_MAP[extension]
     : CONFIG_MAP.js;
   const fileContent = prettier.format(content, formatOptions);
-  const targetDir = path.resolve(configDir);
-  const filePath = path.resolve(targetDir, filename);
+  const filePath = path.join(configDir, filename);
   const directory = path.dirname(filePath);
-  if (directory) {
+  if (directory && directory !== '.') {
     fs.mkdirSync(directory, { recursive: true });
   }
   const flag = shouldOverwrite ? 'w' : 'wx';

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -17,6 +17,7 @@ import fs from 'fs';
 import path from 'path';
 import { promisify } from 'util';
 import prettier from 'prettier';
+import { includes } from 'lodash/fp';
 import pkgUp from 'pkg-up';
 
 import { Language, PackageJson } from '../types/shared';
@@ -24,16 +25,28 @@ import prettierConfig from '../prettier';
 
 const writeFileAsync = promisify(fs.writeFile);
 
+const CONFIG_MAP: { [key: string]: any } = {
+  '.js': prettierConfig({ language: Language.JAVASCRIPT }),
+  '.yaml': { parser: 'yaml' },
+};
+
 export function writeFile(
   configDir: string,
   filename: string,
   content: string,
   shouldOverwrite = false,
 ): Promise<void> {
-  const formatOptions = prettierConfig({ language: Language.TYPESCRIPT });
+  const extension = path.extname(filename);
+  const formatOptions = includes(extension, ['.js', '.yaml'])
+    ? CONFIG_MAP[extension]
+    : CONFIG_MAP.js;
   const fileContent = prettier.format(content, formatOptions);
   const targetDir = path.resolve(configDir);
   const filePath = path.resolve(targetDir, filename);
+  const directory = path.dirname(filePath);
+  if (directory) {
+    fs.mkdirSync(directory, { recursive: true });
+  }
   const flag = shouldOverwrite ? 'w' : 'wx';
 
   return writeFileAsync(filePath, fileContent, { flag });

--- a/src/lib/handlebars.spec.ts
+++ b/src/lib/handlebars.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2020, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Handlebars } from './handlebars';
+
+describe('Handlebars', () => {
+  describe('includes', () => {
+    const input = `
+{{#includes foo "bar"}}
+hello
+{{/includes}}
+`;
+
+    it('should return the block content if the value is included in the array', () => {
+      const template = Handlebars.compile(input);
+      const actual = template({ foo: ['bar'] });
+      const expected = 'hello';
+      expect(actual).toInclude(expected);
+    });
+
+    it('should return nothin if the value is not included in the array', () => {
+      const template = Handlebars.compile(input);
+      const actual = template({ foo: ['bazz'] });
+      const expected = 'hello';
+      expect(actual).not.toInclude(expected);
+    });
+  });
+});

--- a/src/lib/handlebars.ts
+++ b/src/lib/handlebars.ts
@@ -13,24 +13,12 @@
  * limitations under the License.
  */
 
-import { Handlebars } from '../../lib/handlebars';
-import { Options, File, CI } from '../../types/shared';
+import { includes } from 'lodash/fp';
+import Handlebars from 'handlebars';
 
-import * as githubActions from './github-actions';
+// eslint-disable-next-line no-confusing-arrow
+Handlebars.registerHelper('includes', (array, value, options) =>
+  includes(value, array) ? options.fn(options.data.root) : null,
+);
 
-const PLATFORM_MAP = {
-  [CI.GITHUB_ACTIONS]: githubActions,
-};
-
-export const files = (options: Options): File[] => {
-  const { ci = CI.GITHUB_ACTIONS } = options;
-  const platform = PLATFORM_MAP[ci];
-  const template = Handlebars.compile(platform.template);
-  const content = template(options);
-  return [
-    {
-      name: platform.fileName,
-      content,
-    },
-  ];
-};
+export { Handlebars };

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -55,9 +55,20 @@ const release = {
   prompts: [Prompt.PUBLISH],
 };
 
+const ci = {
+  name: formatName(
+    'Continous Integration',
+    'Validate the code on every push using the configured presets',
+  ),
+  value: Preset.CI,
+  short: 'CI',
+  tools: [Tool.CI],
+  prompts: [Prompt.CI],
+};
+
 function formatName(name: string, description: string): string {
   return [`${chalk.bold(name)}:`, description].join(' ');
 }
 
-export const presets = { lint, templates, release };
-export const presetChoices = [lint, templates, release];
+export const presets = { lint, templates, release, ci };
+export const presetChoices = [lint, templates, release, ci];

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -91,6 +91,6 @@ export interface ToolOptions {
 
 export type PackageJson = {
   scripts: { [key: string]: string };
-  bin: string;
-  [key: string]: object | string;
+  bin?: string;
+  [key: string]: object | string | undefined;
 };

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -61,6 +61,7 @@ export interface Options {
   frameworks?: Framework[];
   openSource?: boolean;
   publish?: boolean;
+  overwrite?: boolean;
 }
 
 export type File = {

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -17,6 +17,7 @@ export enum Preset {
   LINT = 'lint',
   RELEASE = 'release',
   TEMPLATES = 'templates',
+  CI = 'ci',
 }
 
 export enum Tool {
@@ -26,6 +27,7 @@ export enum Tool {
   LINT_STAGED = 'lint-staged',
   PLOP = 'plop',
   SEMANTIC_RELEASE = 'semantic-release',
+  CI = 'ci',
 }
 
 export enum Prompt {
@@ -34,6 +36,7 @@ export enum Prompt {
   FRAMEWORKS = 'frameworks',
   OPEN_SOURCE = 'open-source',
   PUBLISH = 'publish',
+  CI = 'ci',
 }
 
 export enum Language {
@@ -53,12 +56,17 @@ export enum Framework {
   CYPRESS = 'Cypress',
 }
 
+export enum CI {
+  GITHUB_ACTIONS = 'github-actions',
+}
+
 export interface Options {
   presets: Preset[];
   configDir: string;
   language?: Language;
   environments?: Environment[];
   frameworks?: Framework[];
+  ci?: CI;
   openSource?: boolean;
   publish?: boolean;
   overwrite?: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3449,6 +3449,17 @@ handlebars@^4.4.0:
   optionalDependencies:
     uglify-js "^3.1.4"
 
+handlebars@^4.7.3:
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.3.tgz#8ece2797826886cf8082d1726ff21d2a022550ee"
+  integrity sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==
+  dependencies:
+    neo-async "^2.6.0"
+    optimist "^0.6.1"
+    source-map "^0.6.1"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"


### PR DESCRIPTION
## Purpose

All the linting and test presets from Foundry don't help if they're not run regularly against the code. Ideally, they run on every push in CI.

## Approach & changes

- add a new CI preset that bootstraps a GitHub Actions workflow with the scripts from the presets that are being configured