### PR TITLE
fix(prettier): infer parser from file extension

### DIFF
--- a/src/configs/prettier/__snapshots__/config.spec.ts.snap
+++ b/src/configs/prettier/__snapshots__/config.spec.ts.snap
@@ -7,7 +7,6 @@ Object {
   "endOfLine": "lf",
   "jsxBracketSameLine": false,
   "jsxSingleQuote": false,
-  "parser": "typescript",
   "printWidth": 80,
   "quoteProps": "consistent",
   "semi": true,

--- a/src/configs/prettier/config.ts
+++ b/src/configs/prettier/config.ts
@@ -13,30 +13,17 @@
  * limitations under the License.
  */
 
-import { Options as PrettierConfig, BuiltInParserName } from 'prettier';
+import { Options as PrettierConfig } from 'prettier';
 
-import { Language } from '../../types/shared';
+import { Options } from '../../types/shared';
 
-type PrettierOptions = {
-  language: Language;
-};
-
-type Parsers = {
-  [key in Language]: BuiltInParserName;
-};
-
-const PARSERS: Parsers = {
-  [Language.JAVASCRIPT]: 'babel',
-  [Language.TYPESCRIPT]: 'typescript',
-};
+export type PrettierOptions = Partial<Options>;
 
 export function config(
-  options: PrettierOptions = { language: Language.TYPESCRIPT },
+  options: PrettierOptions = {},
   overrides: PrettierConfig = {},
 ): PrettierConfig {
-  const { language } = options;
   const base: PrettierConfig = {
-    parser: PARSERS[language],
     printWidth: 80,
     tabWidth: 2,
     useTabs: false,

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -16,18 +16,19 @@
 import fs from 'fs';
 import path from 'path';
 import { promisify } from 'util';
-import prettier from 'prettier';
-import { includes } from 'lodash/fp';
+import prettier, { Options as PrettierConfig } from 'prettier';
+
 import pkgUp from 'pkg-up';
 
-import { Language, PackageJson } from '../types/shared';
+import { PackageJson } from '../types/shared';
 import prettierConfig from '../prettier';
 
 const writeFileAsync = promisify(fs.writeFile);
 
 export function formatContent(fileName: string, content: string): string {
-  const configMap: { [key: string]: any } = {
-    '.js': prettierConfig({ language: Language.JAVASCRIPT }),
+  const configMap: { [key: string]: PrettierConfig } = {
+    '.js': prettierConfig({}, { parser: 'babel' }),
+    '.json': { parser: 'json' },
     '.yaml': { parser: 'yaml' },
   };
 


### PR DESCRIPTION
## Purpose

Explicitly setting the `parser` option prevented prettier from parsing and formatting other file
formats based on their file extension.

## Approach & Changes

- remove hard-coded `parser` option from prettier config