### PR TITLE
fix: correct typo in component template

### DIFF
--- a/src/configs/plop/templates/js/class-component.hbs
+++ b/src/configs/plop/templates/js/class-component.hbs
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 export default class {{ name }} extends Component {
   static propTypes = {
     /**
-    * A consice description of the example prop.
+    * A concise description of the example prop.
     */
     example: PropTypes.string
   };

--- a/src/configs/plop/templates/js/functional-component.hbs
+++ b/src/configs/plop/templates/js/functional-component.hbs
@@ -10,7 +10,7 @@ const {{ name }} = (props) => {
 
 {{ name }}.propTypes = {
   /**
-   * A consice description of the example prop.
+   * A concise description of the example prop.
    */
   example: PropTypes.string
 };

--- a/src/configs/plop/templates/js/styled-component.hbs
+++ b/src/configs/plop/templates/js/styled-component.hbs
@@ -13,7 +13,7 @@ const {{ name }} = styled('element')(baseStyles);
 
 {{ name }}.propTypes = {
   /**
-   * A consice description of the example prop.
+   * A concise description of the example prop.
    */
   example: PropTypes.string
 };

--- a/src/configs/plop/templates/ts/class-component.hbs
+++ b/src/configs/plop/templates/ts/class-component.hbs
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 
 export interface {{ name }}Props {
   /**
-   * A consice description of the example prop.
+   * A concise description of the example prop.
    */
   example?: string;
 }

--- a/src/configs/plop/templates/ts/functional-component.hbs
+++ b/src/configs/plop/templates/ts/functional-component.hbs
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from 'react';
 
 export interface {{ name }}Props { 
   /**
-   * A consice description of the example prop.
+   * A concise description of the example prop.
    */
   example?: string;
 }

--- a/src/configs/plop/templates/ts/styled-component.hbs
+++ b/src/configs/plop/templates/ts/styled-component.hbs
@@ -8,7 +8,7 @@ export interface {{ name }}Props {
    */
   className?: string;
   /**
-   * A consice description of the example prop.
+   * A concise description of the example prop.
    */
   example?: string;
 }


### PR DESCRIPTION
## Purpose

In the component templates, as a description for prop types, `concise` was spelled `consice`.

## Approach and changes

Fix all occurrences of the typo in the templates.

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [ ] Unit and integration tests
