### PR TITLE
fix(init): initialize package scripts

### DIFF
--- a/src/lib/files.spec.ts
+++ b/src/lib/files.spec.ts
@@ -106,6 +106,25 @@ describe('files', () => {
       expect(actual).toEqual(expected);
     });
 
+    it('should initialize the scripts if they do not exist yet', () => {
+      const packageJson = {};
+      const name = 'lint';
+      const command = 'foundry run eslint src';
+      const shouldOverwrite = false;
+
+      const actual = addPackageScript(
+        packageJson,
+        name,
+        command,
+        shouldOverwrite,
+      );
+
+      const expected = {
+        scripts: { lint: 'foundry run eslint src' },
+      };
+      expect(actual).toEqual(expected);
+    });
+
     it('should throw an error if a conflicting script exists', () => {
       const packageJson = { scripts: { lint: 'eslint .' } };
       const name = 'lint';

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -73,6 +73,12 @@ export function addPackageScript(
   command: string,
   shouldOverwrite = false,
 ): PackageJson {
+  if (!packageJson.scripts) {
+    // eslint-disable-next-line no-param-reassign
+    packageJson.scripts = { [name]: command };
+    return packageJson;
+  }
+
   const hasConflict = Boolean(packageJson.scripts[name]);
   if (hasConflict && !shouldOverwrite) {
     throw new Error(`A script with the name "${name}" already exists.`);

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -90,7 +90,7 @@ export interface ToolOptions {
 }
 
 export type PackageJson = {
-  scripts: { [key: string]: string };
+  scripts?: { [key: string]: string };
   bin?: string;
   [key: string]: object | string | undefined;
 };


### PR DESCRIPTION
Fixes #97.

## Purpose

`foundry init` doesn't add custom commands to `package.json` when the package doesn't contain the `scripts` property.

## Approach and changes

- Initialize the `scripts` property if it doesn't exist yet

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
