### PR TITLE
perf(ci): improve caching when using yarn

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,15 +12,17 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 10.x
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
       - name: Cache dependencies
         uses: actions/cache@v1
+        id: yarn-cache
         with:
-          path: node_modules
-          key: ${{ runner.OS }}-node-${{ hashFiles('**/yarn.lock') }}
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.OS }}-node-${{ env.cache-name }}-
-            ${{ runner.OS }}-node-
-            ${{ runner.OS }}-
+            ${{ runner.os }}-yarn-
       - name: Install dependencies
         run: |
           npm install -g yarn

--- a/src/configs/ci/github-actions.ts
+++ b/src/configs/ci/github-actions.ts
@@ -32,15 +32,17 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 10.x
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
       - name: Cache dependencies
         uses: actions/cache@v1
+        id: yarn-cache
         with:
-          path: node_modules
-          key: $\\{{ runner.OS }}-node-$\\{{ hashFiles('**/yarn.lock') }}
+          path: $\\{{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: $\\{{ runner.os }}-yarn-$\\{{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            $\\{{ runner.OS }}-node-$\\{{ env.cache-name }}-
-            $\\{{ runner.OS }}-node-
-            $\\{{ runner.OS }}-
+            $\\{{ runner.os }}-yarn-
       - name: Install dependencies
         run: |
           npm install -g yarn


### PR DESCRIPTION
## Purpose

The caching of the node modules in CI doesn't seem to work, because `yarn` caches modules differently.

## Approach and changes

- adapt caching setup from the [official docs](https://github.com/actions/cache/blob/master/examples.md#node---yarn)

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
