### PR TITLE
feat(eslint): turn off explicit-function-return-type rule

### DIFF
--- a/src/configs/eslint/__snapshots__/config.spec.ts.snap
+++ b/src/configs/eslint/__snapshots__/config.spec.ts.snap
@@ -932,14 +932,6 @@ Object {
     },
     Object {
       "files": Array [
-        "**/*.js",
-      ],
-      "rules": Object {
-        "@typescript-eslint/explicit-function-return-type": "off",
-      },
-    },
-    Object {
-      "files": Array [
         "**/*.d.ts",
       ],
       "rules": Object {
@@ -990,6 +982,7 @@ Object {
   ],
   "root": true,
   "rules": Object {
+    "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-use-before-define": Array [
       "error",
       Object {
@@ -1091,14 +1084,6 @@ Object {
     },
     Object {
       "files": Array [
-        "**/*.js",
-      ],
-      "rules": Object {
-        "@typescript-eslint/explicit-function-return-type": "off",
-      },
-    },
-    Object {
-      "files": Array [
         "**/*.d.ts",
       ],
       "rules": Object {
@@ -1140,6 +1125,7 @@ Object {
   ],
   "root": true,
   "rules": Object {
+    "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-use-before-define": Array [
       "error",
       Object {
@@ -1246,14 +1232,6 @@ Object {
     },
     Object {
       "files": Array [
-        "**/*.js",
-      ],
-      "rules": Object {
-        "@typescript-eslint/explicit-function-return-type": "off",
-      },
-    },
-    Object {
-      "files": Array [
         "**/*.d.ts",
       ],
       "rules": Object {
@@ -1315,6 +1293,7 @@ Object {
   ],
   "root": true,
   "rules": Object {
+    "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-use-before-define": Array [
       "error",
       Object {
@@ -1419,14 +1398,6 @@ Object {
     },
     Object {
       "files": Array [
-        "**/*.js",
-      ],
-      "rules": Object {
-        "@typescript-eslint/explicit-function-return-type": "off",
-      },
-    },
-    Object {
-      "files": Array [
         "**/*.d.ts",
       ],
       "rules": Object {
@@ -1471,6 +1442,7 @@ Object {
   ],
   "root": true,
   "rules": Object {
+    "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-use-before-define": Array [
       "error",
       Object {
@@ -1579,14 +1551,6 @@ Object {
     },
     Object {
       "files": Array [
-        "**/*.js",
-      ],
-      "rules": Object {
-        "@typescript-eslint/explicit-function-return-type": "off",
-      },
-    },
-    Object {
-      "files": Array [
         "**/*.d.ts",
       ],
       "rules": Object {
@@ -1647,6 +1611,7 @@ Object {
   ],
   "root": true,
   "rules": Object {
+    "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-use-before-define": Array [
       "error",
       Object {
@@ -1752,14 +1717,6 @@ Object {
     },
     Object {
       "files": Array [
-        "**/*.js",
-      ],
-      "rules": Object {
-        "@typescript-eslint/explicit-function-return-type": "off",
-      },
-    },
-    Object {
-      "files": Array [
         "**/*.d.ts",
       ],
       "rules": Object {
@@ -1811,6 +1768,7 @@ Object {
   ],
   "root": true,
   "rules": Object {
+    "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-use-before-define": Array [
       "error",
       Object {
@@ -1921,14 +1879,6 @@ Object {
     },
     Object {
       "files": Array [
-        "**/*.js",
-      ],
-      "rules": Object {
-        "@typescript-eslint/explicit-function-return-type": "off",
-      },
-    },
-    Object {
-      "files": Array [
         "**/*.d.ts",
       ],
       "rules": Object {
@@ -2000,6 +1950,7 @@ Object {
   ],
   "root": true,
   "rules": Object {
+    "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-use-before-define": Array [
       "error",
       Object {
@@ -2108,14 +2059,6 @@ Object {
     },
     Object {
       "files": Array [
-        "**/*.js",
-      ],
-      "rules": Object {
-        "@typescript-eslint/explicit-function-return-type": "off",
-      },
-    },
-    Object {
-      "files": Array [
         "**/*.d.ts",
       ],
       "rules": Object {
@@ -2170,6 +2113,7 @@ Object {
   ],
   "root": true,
   "rules": Object {
+    "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-use-before-define": Array [
       "error",
       Object {

--- a/src/configs/eslint/config.ts
+++ b/src/configs/eslint/config.ts
@@ -125,6 +125,7 @@ function customizeLanguage(language?: Language): EslintConfig {
         },
       },
       rules: {
+        '@typescript-eslint/explicit-function-return-type': 'off',
         '@typescript-eslint/no-use-before-define': [
           'error',
           { functions: false },
@@ -132,12 +133,6 @@ function customizeLanguage(language?: Language): EslintConfig {
         'react/prop-types': 'off',
       },
       overrides: [
-        {
-          files: ['**/*.js'],
-          rules: {
-            '@typescript-eslint/explicit-function-return-type': 'off',
-          },
-        },
         {
           files: ['**/*.d.ts'],
           rules: {


### PR DESCRIPTION
## Purpose

The [`explicit-function-return-type`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-function-return-type.md) rule is more annoying than helpful. In most cases, TypeScript is able to infer the type, so the explicit type is not necessary. TypeScript and Eslint should be helpful, not annoying and cumbersome.

## Approach and changes

- disable `explicit-function-return-type` rule

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
