### PR TITLE
feat(release): rename default git branch to "main"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,11 +23,11 @@ If you feel another member of the community violated our CoC or you are experien
 _Before you get started, make sure you have [Node](https://nodejs.org/en/) v10.18+ and the [Yarn CLI](https://yarnpkg.com/en/docs/install) installed on your computer._
 
 1. Find an existing issue to work on or follow `Submitting an issue` to create one that you're also going to fix. Make sure to notify that you're working on a fix for the issue you picked.
-2. Branch out from latest `master`.
+2. Branch out from latest `main`.
 3. Code, add, commit and push your changes in your branch.
 4. Make sure that tests and linter(s) pass locally for you.
 5. Submit a PR.
-6. Collaborate with the codeowners/reviewers to merge this to `master`.
+6. Collaborate with the codeowners/reviewers to merge this to `main`.
 
 ## Common commands
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 # Foundry
 
-[![NPM version](https://img.shields.io/npm/v/@sumup/foundry)](https://www.npmjs.com/package/@sumup/foundry) [![Code coverage](https://img.shields.io/codecov/c/github/sumup-oss/foundry)](https://codecov.io/gh/sumup-oss/foundry) [![License](https://img.shields.io/github/license/sumup-oss/foundry)](https://github.com/sumup-oss/foundry/blob/master/LICENSE) [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
+[![NPM version](https://img.shields.io/npm/v/@sumup/foundry)](https://www.npmjs.com/package/@sumup/foundry) [![Code coverage](https://img.shields.io/codecov/c/github/sumup-oss/foundry)](https://codecov.io/gh/sumup-oss/foundry) [![License](https://img.shields.io/github/license/sumup-oss/foundry)](https://github.com/sumup-oss/foundry/blob/main/LICENSE) [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 
 A toolkit that makes it a breeze to set up and maintain JavaScript + TypeScript applications. Foundry has presets for [🔍 linting](#-lint), [🚀 releasing](#-release), [🤖 continuous integration (CI)](#-continuous-integration-ci), and [🖇️ templates](#-templates) and currently supports [React](https://reactjs.org), [Emotion](https://emotion.sh/), [Jest](https://jestjs.io/), [Cypress](https://www.cypress.io/), and [Node](https://nodejs.org/en/).
 
 </div>
 
-**Table of contents**
+## Table of contents
 
 - [Getting Started](#getting-started)
   - [Installation](#installation)
@@ -170,7 +170,7 @@ Plop's configuration options:
 
 Plop uses [Handlebar](http://handlebarsjs.com/) templates to generate the files. If you'd like to override a built-in template, you can specify a custom template directory (see config options above). Plop will first check if a custom template exists, otherwise, it will fallback to the default template.
 
-To see which variables are available for use in a Handlebars template, have a look at the [default templates](https://github.com/sumup-oss/foundry/tree/master/src/configs/plop/templates).
+To see which variables are available for use in a Handlebars template, have a look at the [default templates](https://github.com/sumup-oss/foundry/tree/main/src/configs/plop/templates).
 
 ## Running a tool
 

--- a/src/configs/semantic-release/__snapshots__/config.spec.ts.snap
+++ b/src/configs/semantic-release/__snapshots__/config.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`semantic-release with options should return a config to publish to NPM 
 Object {
   "branches": Array [
     "+([0-9])?(.{+([0-9]),x}).x",
-    "master",
+    "main",
     "next",
     Object {
       "name": "alpha",
@@ -18,6 +18,7 @@ Object {
       "name": "canary",
       "prerelease": true,
     },
+    "master",
   ],
   "plugins": Array [
     "@semantic-release/commit-analyzer",
@@ -32,7 +33,7 @@ exports[`semantic-release with options should return a default config 1`] = `
 Object {
   "branches": Array [
     "+([0-9])?(.{+([0-9]),x}).x",
-    "master",
+    "main",
     "next",
     Object {
       "name": "alpha",
@@ -46,6 +47,7 @@ Object {
       "name": "canary",
       "prerelease": true,
     },
+    "master",
   ],
   "plugins": Array [
     "@semantic-release/commit-analyzer",

--- a/src/configs/semantic-release/config.spec.ts
+++ b/src/configs/semantic-release/config.spec.ts
@@ -33,10 +33,10 @@ describe('semantic-release', () => {
     it('should override the default config', () => {
       const options = undefined;
       const overrides = {
-        branches: ['master'],
+        branches: ['main'],
       };
       const actual = config(options, overrides);
-      expect(actual).toEqual(expect.objectContaining({ branches: ['master'] }));
+      expect(actual).toEqual(expect.objectContaining({ branches: ['main'] }));
     });
   });
 });

--- a/src/configs/semantic-release/config.ts
+++ b/src/configs/semantic-release/config.ts
@@ -32,11 +32,13 @@ interface SemanticReleaseConfig {
 const base: SemanticReleaseConfig = {
   branches: [
     '+([0-9])?(.{+([0-9]),x}).x',
-    'master',
+    'main',
     'next',
     { name: 'alpha', prerelease: true },
     { name: 'beta', prerelease: true },
     { name: 'canary', prerelease: true },
+    // @deprecated, remove in next major release
+    'master',
   ],
   plugins: [
     '@semantic-release/commit-analyzer',


### PR DESCRIPTION
## Purpose

The origin of the "master" name for the default git branch is [likely rooted](https://boleary.dev/blog/2020-06-10-i-was-wrong-about-git-master.html) in master/slave terminology.

[Una Kravets](https://twitter.com/Una) summarized the arguments for switching to "main" in [a tweet](https://twitter.com/Una/status/1271181775130279936):

> 1. “Main” is shorter! Yay brevity!
> 2. It’s even easier to remember, tbh
> 3. If it makes any of my teammates feel an ounce more comfortable, let’s do it!
> 4. If it prevents even a single black person from feeling more isolated in the tech community, feels like a no brainer to me!

## Approach and changes

- Add "main" to the list of branches on which semantic-release should run. Note that "master" is still supported to make the transition easier. It will be removed in the next major.
- Replace references to "master" with "main" in preparation of renaming the default branch for the Foundry repo

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
