### PR TITLE
feat(plop): update default templates

### DIFF
--- a/src/configs/plop/templates/js/component-spec.hbs
+++ b/src/configs/plop/templates/js/component-spec.hbs
@@ -18,7 +18,7 @@ describe.skip('{{ name }}', () => {
 
   {{#if (not type 'styled') }}
   describe('business logic', () => {
-    it('should have tests');
+    it.todo('should have tests');
   });
 
   {{/if}}

--- a/src/configs/plop/templates/js/styled-component.hbs
+++ b/src/configs/plop/templates/js/styled-component.hbs
@@ -18,8 +18,6 @@ const {{ name }} = styled('element')(baseStyles);
   example: PropTypes.string
 };
 
-{{ name }}.defaultProps = {};
-
 /**
  * @component
  */

--- a/src/configs/plop/templates/ts/component-spec.hbs
+++ b/src/configs/plop/templates/ts/component-spec.hbs
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { create, renderToHtml, axe, RenderFn } from 'config/test-utils';
+import { create, renderToHtml, axe, RenderFn } from '../../util/test-utils';
 
 import { {{ name }}, {{ name }}Props } from './{{ name }}';
 
@@ -10,7 +10,7 @@ describe('{{ name }}', () => {
   }
 
   describe('styles', () => {
-    it.todo('should render with default styles', () => {
+    it('should render with default styles', () => {
       const actual = render{{ name }}(create);
       expect(actual).toMatchSnapshot();
     });
@@ -23,7 +23,7 @@ describe('{{ name }}', () => {
 
   {{/if}}
   describe('accessibility', () => {
-    it.todo('should meet accessibility guidelines', async () => {
+    it('should meet accessibility guidelines', async () => {
       const wrapper = render{{ name }}(renderToHtml);
       const actual = await axe(wrapper);
       expect(actual).toHaveNoViolations();

--- a/src/configs/plop/templates/ts/functional-component.hbs
+++ b/src/configs/plop/templates/ts/functional-component.hbs
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 
 export interface {{ name }}Props { 
   /**
@@ -10,6 +10,6 @@ export interface {{ name }}Props {
 /**
  * Describe {{ name }} here.
  */
-export const {{ name }}: FunctionComponent<{{ name }}Props> = (props) => {
+export const {{ name }} = (props: {{ name }}Props) => {
   return null;
 };

--- a/src/configs/plop/templates/ts/story.hbs
+++ b/src/configs/plop/templates/ts/story.hbs
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 
 import { {{ name }} } from './{{ name }}';
 
@@ -7,4 +7,4 @@ export default {
   component: {{ name }}
 };
 
-export const base: FunctionComponent = () => <{{ name }} />;
+export const base = () => <{{ name }} />;

--- a/src/configs/plop/templates/ts/styled-component.hbs
+++ b/src/configs/plop/templates/ts/styled-component.hbs
@@ -1,6 +1,6 @@
 import { css } from '@emotion/core';
 
-import styled from 'styles/styled';
+import styled from '../../styles/styled';
 
 export interface {{ name }}Props {
   /**
@@ -21,5 +21,3 @@ const baseStyles = ({ theme }) => css`
  * Describe {{ name }} here.
  */
 export const {{ name }} = styled('element')<{{ name }}Props>(baseStyles);
-
-{{ name }}.defaultProps = {};


### PR DESCRIPTION
## Approach and changes

- Remove FunctionComponent type based on @fernandofleury's suggestion in https://github.com/sumup-oss/circuit-ui/pull/615#discussion_r442273911
- Remove default props since will drop support for them eventually and they can be replaced by [default function params](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters)
- Update unit tests to avoid test/lint errors after the initial generation

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
