### PR TITLE
fix(lint): include JSON files when linting TypeScript

### DIFF
--- a/src/configs/eslint/__snapshots__/config.spec.ts.snap
+++ b/src/configs/eslint/__snapshots__/config.spec.ts.snap
@@ -1050,6 +1050,9 @@ Object {
       "modules": true,
     },
     "ecmaVersion": 6,
+    "extraFileExtensions": Array [
+      ".json",
+    ],
     "project": Array [
       "./tsconfig.json",
     ],
@@ -1202,6 +1205,9 @@ Object {
       "modules": true,
     },
     "ecmaVersion": 6,
+    "extraFileExtensions": Array [
+      ".json",
+    ],
     "project": Array [
       "./tsconfig.json",
     ],
@@ -1379,6 +1385,9 @@ Object {
       "modules": true,
     },
     "ecmaVersion": 6,
+    "extraFileExtensions": Array [
+      ".json",
+    ],
     "project": Array [
       "./tsconfig.json",
     ],
@@ -1535,6 +1544,9 @@ Object {
       "modules": true,
     },
     "ecmaVersion": 6,
+    "extraFileExtensions": Array [
+      ".json",
+    ],
     "project": Array [
       "./tsconfig.json",
     ],
@@ -1715,6 +1727,9 @@ Object {
       "modules": true,
     },
     "ecmaVersion": 6,
+    "extraFileExtensions": Array [
+      ".json",
+    ],
     "project": Array [
       "./tsconfig.json",
     ],
@@ -1881,6 +1896,9 @@ Object {
       "modules": true,
     },
     "ecmaVersion": 6,
+    "extraFileExtensions": Array [
+      ".json",
+    ],
     "project": Array [
       "./tsconfig.json",
     ],
@@ -2072,6 +2090,9 @@ Object {
       "modules": true,
     },
     "ecmaVersion": 6,
+    "extraFileExtensions": Array [
+      ".json",
+    ],
     "project": Array [
       "./tsconfig.json",
     ],
@@ -2242,6 +2263,9 @@ Object {
       "modules": true,
     },
     "ecmaVersion": 6,
+    "extraFileExtensions": Array [
+      ".json",
+    ],
     "project": Array [
       "./tsconfig.json",
     ],

--- a/src/configs/eslint/config.ts
+++ b/src/configs/eslint/config.ts
@@ -121,6 +121,7 @@ function customizeLanguage(language?: Language): EslintConfig {
       parserOptions: {
         tsconfigRootDir: process.cwd(),
         project: ['./tsconfig.json'],
+        extraFileExtensions: ['.json'],
         sourceType: 'module',
         ecmaVersion: 6,
         ecmaFeatures: {

--- a/src/configs/eslint/index.ts
+++ b/src/configs/eslint/index.ts
@@ -42,6 +42,7 @@ export const files = (options: Options): File[] => [
       /*.config.js
       /*rc.js
       plopfile.js
+      tsconfig.json
     `}\n`,
   },
 ];


### PR DESCRIPTION
Addresses #123.

## Purpose

Eslint fails on linting `.json` files when TypeScript is used.

## Approach and changes

- Include `.json` files in the Eslint parser config
- Ignore the `tsconfig.json` file for Eslint since it is excluded by TypeScript by default

You might still have to manually edit your `tsconfig.json` file to include `.json` files. Make sure you've set `compilerOptions.resolveJsonModule` to `true` and included `.json` files in the `include` option.

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
