### PR TITLE
feat(template): update spec file template

### DIFF
--- a/src/configs/plop/templates/ts/component-spec.hbs
+++ b/src/configs/plop/templates/ts/component-spec.hbs
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { create, renderToHtml, axe, RenderFn } from '../../util/test-utils';
+import { create, renderToHtml, axe, RenderFn } from '../../test-utils';
 
 import { {{ name }}, {{ name }}Props } from './{{ name }}';
 

--- a/src/configs/plop/templates/ts/component-spec.hbs
+++ b/src/configs/plop/templates/ts/component-spec.hbs
@@ -1,18 +1,18 @@
 import React from 'react';
 
-import { create, renderToHtml, axe, RenderFn } from '../../test-utils';
+import { render, axe } from '../../test-utils';
 
 import { {{ name }}, {{ name }}Props } from './{{ name }}';
 
 describe('{{ name }}', () => {
-  function render{{ name }}(renderFn: RenderFn, props: {{ name }}Props = {}) {
-    return renderFn(<{{ name }} {...props} />);
+  function render{{ name }}(props: {{ name }}Props = {}) {
+    return render(<{{ name }} {...props} />);
   }
 
   describe('styles', () => {
     it('should render with default styles', () => {
-      const actual = render{{ name }}(create);
-      expect(actual).toMatchSnapshot();
+      const { container } = render{{ name }}();
+      expect(container).toMatchSnapshot();
     });
   });
 
@@ -24,8 +24,8 @@ describe('{{ name }}', () => {
   {{/if}}
   describe('accessibility', () => {
     it('should meet accessibility guidelines', async () => {
-      const wrapper = render{{ name }}(renderToHtml);
-      const actual = await axe(wrapper);
+      const { container } = render{{ name }}();
+      const actual = await axe(container);
       expect(actual).toHaveNoViolations();
     });
   });


### PR DESCRIPTION
## Purpose

The [`create-sumup-react-app`](https://github.com/sumup/create-sumup-react-app) and [`create-sumup-next-app`](https://github.com/sumup/create-sumup-next-app) starters are being updated. The location of the `test-utils` file has changed, this should be reflected in Foundry.

## Approach and changes

- update the import in the spec template to point to the project root
- simplify the spec template: the `render` function covers all use cases

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
