### PR TITLE
fix(lint): disable TypeScript rules in JavaScript files

### DIFF
--- a/src/configs/eslint/__snapshots__/config.spec.ts.snap
+++ b/src/configs/eslint/__snapshots__/config.spec.ts.snap
@@ -1028,6 +1028,21 @@ Object {
     },
     Object {
       "files": Array [
+        "**/*.js",
+      ],
+      "rules": Object {
+        "@typescript-eslint/explicit-module-boundary-types": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-unsafe-call": "off",
+        "@typescript-eslint/no-unsafe-member-access": "off",
+        "@typescript-eslint/no-unsafe-return": "off",
+        "@typescript-eslint/restrict-plus-operands": "off",
+        "@typescript-eslint/restrict-template-expressions": "off",
+      },
+    },
+    Object {
+      "files": Array [
         "**/*.spec.*",
       ],
       "rules": Object {
@@ -1193,6 +1208,21 @@ Object {
     },
     Object {
       "files": Array [
+        "**/*.js",
+      ],
+      "rules": Object {
+        "@typescript-eslint/explicit-module-boundary-types": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-unsafe-call": "off",
+        "@typescript-eslint/no-unsafe-member-access": "off",
+        "@typescript-eslint/no-unsafe-return": "off",
+        "@typescript-eslint/restrict-plus-operands": "off",
+        "@typescript-eslint/restrict-template-expressions": "off",
+      },
+    },
+    Object {
+      "files": Array [
         "**/*.spec.*",
       ],
       "rules": Object {
@@ -1350,6 +1380,21 @@ Object {
         ],
         "node/no-extraneous-import": "off",
         "spaced-comment": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "**/*.js",
+      ],
+      "rules": Object {
+        "@typescript-eslint/explicit-module-boundary-types": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-unsafe-call": "off",
+        "@typescript-eslint/no-unsafe-member-access": "off",
+        "@typescript-eslint/no-unsafe-return": "off",
+        "@typescript-eslint/restrict-plus-operands": "off",
+        "@typescript-eslint/restrict-template-expressions": "off",
       },
     },
     Object {
@@ -1529,6 +1574,21 @@ Object {
         ],
         "node/no-extraneous-import": "off",
         "spaced-comment": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "**/*.js",
+      ],
+      "rules": Object {
+        "@typescript-eslint/explicit-module-boundary-types": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-unsafe-call": "off",
+        "@typescript-eslint/no-unsafe-member-access": "off",
+        "@typescript-eslint/no-unsafe-return": "off",
+        "@typescript-eslint/restrict-plus-operands": "off",
+        "@typescript-eslint/restrict-template-expressions": "off",
       },
     },
     Object {
@@ -1699,6 +1759,21 @@ Object {
     },
     Object {
       "files": Array [
+        "**/*.js",
+      ],
+      "rules": Object {
+        "@typescript-eslint/explicit-module-boundary-types": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-unsafe-call": "off",
+        "@typescript-eslint/no-unsafe-member-access": "off",
+        "@typescript-eslint/no-unsafe-return": "off",
+        "@typescript-eslint/restrict-plus-operands": "off",
+        "@typescript-eslint/restrict-template-expressions": "off",
+      },
+    },
+    Object {
+      "files": Array [
         "**/*.spec.*",
       ],
       "rules": Object {
@@ -1878,6 +1953,21 @@ Object {
     },
     Object {
       "files": Array [
+        "**/*.js",
+      ],
+      "rules": Object {
+        "@typescript-eslint/explicit-module-boundary-types": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-unsafe-call": "off",
+        "@typescript-eslint/no-unsafe-member-access": "off",
+        "@typescript-eslint/no-unsafe-return": "off",
+        "@typescript-eslint/restrict-plus-operands": "off",
+        "@typescript-eslint/restrict-template-expressions": "off",
+      },
+    },
+    Object {
+      "files": Array [
         "**/*.spec.*",
       ],
       "rules": Object {
@@ -2049,6 +2139,21 @@ Object {
         ],
         "node/no-extraneous-import": "off",
         "spaced-comment": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "**/*.js",
+      ],
+      "rules": Object {
+        "@typescript-eslint/explicit-module-boundary-types": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-unsafe-call": "off",
+        "@typescript-eslint/no-unsafe-member-access": "off",
+        "@typescript-eslint/no-unsafe-return": "off",
+        "@typescript-eslint/restrict-plus-operands": "off",
+        "@typescript-eslint/restrict-template-expressions": "off",
       },
     },
     Object {
@@ -2242,6 +2347,21 @@ Object {
         ],
         "node/no-extraneous-import": "off",
         "spaced-comment": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "**/*.js",
+      ],
+      "rules": Object {
+        "@typescript-eslint/explicit-module-boundary-types": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-unsafe-call": "off",
+        "@typescript-eslint/no-unsafe-member-access": "off",
+        "@typescript-eslint/no-unsafe-return": "off",
+        "@typescript-eslint/restrict-plus-operands": "off",
+        "@typescript-eslint/restrict-template-expressions": "off",
       },
     },
     Object {

--- a/src/configs/eslint/config.ts
+++ b/src/configs/eslint/config.ts
@@ -164,6 +164,19 @@ function customizeLanguage(language?: Language) {
           },
         },
         {
+          files: ['**/*.js'],
+          rules: {
+            '@typescript-eslint/no-unsafe-call': 'off',
+            '@typescript-eslint/no-explicit-any': 'off',
+            '@typescript-eslint/no-unsafe-return': 'off',
+            '@typescript-eslint/no-unsafe-assignment': 'off',
+            '@typescript-eslint/restrict-plus-operands': 'off',
+            '@typescript-eslint/no-unsafe-member-access': 'off',
+            '@typescript-eslint/restrict-template-expressions': 'off',
+            '@typescript-eslint/explicit-module-boundary-types': 'off',
+          },
+        },
+        {
           files: ['**/*.spec.*'],
           rules: {
             '@typescript-eslint/no-var-requires': 'off',


### PR DESCRIPTION
## Purpose

The upgrade of Eslint and its plugins (#121) wrongly enforced typings-related rules in JavaScript files.

## Approach and changes

- Disable TypeScript rules in JavaScript files

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
