### PR TITLE
feat(plop): add option for target dir

### DIFF
--- a/src/configs/plop/config.ts
+++ b/src/configs/plop/config.ts
@@ -23,8 +23,21 @@ import * as logger from '../../lib/logger';
 import { Language } from '../../types/shared';
 
 interface PlopOptions {
-  templateDir?: string;
+  /**
+   * The programming language for the generated files.
+   */
   language: Language;
+  /**
+   * A path relative to the location of `plopfile.js` where the template files
+   * are located. If a template file isn't found in the custom location, the
+   * default one is used instead.
+   */
+  templateDir?: string;
+  /**
+   * A path relative to the location of `plopfile.js` where the generated files
+   * should be saved. Default: `./src/components`.
+   */
+  targetDir?: string;
 }
 
 enum ComponentType {
@@ -40,13 +53,6 @@ enum FileType {
   SERVICE = 'service',
   SERVICE_SPEC = 'service-spec',
   INDEX = 'index',
-}
-
-interface ActionOptions {
-  name: string;
-  componentType: ComponentType;
-  files: FileType[];
-  destinationPath: string;
 }
 
 const ERRORS = {
@@ -103,7 +109,7 @@ export function config(options: PlopOptions) {
           message: 'Where would you like to put your component?',
           default: relative(
             process.cwd(),
-            `${plop.getPlopfilePath()}/src/components`,
+            join(plop.getPlopfilePath(), options.targetDir || 'src/components'),
           ),
         },
         // Files


### PR DESCRIPTION
Closes #264.

## Approach and changes

- add `targetDir` option to Plop which determines where Plop saves the generated files, defaults to `./src/components`

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
