### PR TITLE
chore: publish to GitHub Packages registry

### DIFF
--- a/.github/prepare-github-release
+++ b/.github/prepare-github-release
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const filePath = path.join(__dirname, '../dist/package.json');
+const pkg = JSON.parse(fs.readFileSync(filePath));
+
+pkg.name = '@sumup-oss/foundry';
+
+fs.writeFileSync(filePath, JSON.stringify(pkg, null, 2));

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,8 +39,12 @@ jobs:
         uses: codecov/codecov-action@v1.0.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-      - name: Release
+      - name: Publish to NPM
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: yarn release
+      - name: Publish to GitHub Packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo $PWD && echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc && ./.github/prepare-github-release && yarn release


### PR DESCRIPTION
## Purpose

GitHub Packages does not allow you to install both private and public packages within the same scope. That's why need to publish OSS packages to the `@sumup-oss` scope in GitHub Packages.

## Approach and changes

- publish Foundry to GitHub Packages under the name `@sumup-oss/foundry`

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
