### PR TITLE
feat: disable unbound method rule for spec files

### DIFF
--- a/src/configs/eslint/__snapshots__/config.spec.ts.snap
+++ b/src/configs/eslint/__snapshots__/config.spec.ts.snap
@@ -329,6 +329,9 @@ Object {
       "plugins": Array [
         "jest",
       ],
+      "rules": Object {
+        "jest/unbound-method": "error",
+      },
     },
   ],
   "parser": "@babel/eslint-parser",
@@ -1031,6 +1034,9 @@ Object {
       "plugins": Array [
         "jest",
       ],
+      "rules": Object {
+        "jest/unbound-method": "error",
+      },
     },
   ],
   "parser": "@babel/eslint-parser",
@@ -1526,6 +1532,7 @@ Object {
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-unsafe-assignment": "off",
         "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/unbound-method": "off",
       },
     },
     Object {
@@ -1766,6 +1773,7 @@ Object {
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-unsafe-assignment": "off",
         "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/unbound-method": "off",
       },
     },
     Object {
@@ -1996,6 +2004,7 @@ Object {
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-unsafe-assignment": "off",
         "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/unbound-method": "off",
       },
     },
     Object {
@@ -2051,6 +2060,9 @@ Object {
       "plugins": Array [
         "jest",
       ],
+      "rules": Object {
+        "jest/unbound-method": "error",
+      },
     },
   ],
   "parser": "@babel/eslint-parser",
@@ -2255,6 +2267,7 @@ Object {
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-unsafe-assignment": "off",
         "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/unbound-method": "off",
       },
     },
     Object {
@@ -2489,6 +2502,7 @@ Object {
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-unsafe-assignment": "off",
         "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/unbound-method": "off",
       },
     },
     Object {
@@ -2728,6 +2742,7 @@ Object {
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-unsafe-assignment": "off",
         "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/unbound-method": "off",
       },
     },
     Object {
@@ -2986,6 +3001,7 @@ Object {
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-unsafe-assignment": "off",
         "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/unbound-method": "off",
       },
     },
     Object {
@@ -3234,6 +3250,7 @@ Object {
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-unsafe-assignment": "off",
         "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/unbound-method": "off",
       },
     },
     Object {
@@ -3303,6 +3320,9 @@ Object {
       "plugins": Array [
         "jest",
       ],
+      "rules": Object {
+        "jest/unbound-method": "error",
+      },
     },
   ],
   "parser": "@babel/eslint-parser",
@@ -3511,6 +3531,7 @@ Object {
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-unsafe-assignment": "off",
         "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/unbound-method": "off",
       },
     },
     Object {
@@ -3763,6 +3784,7 @@ Object {
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-unsafe-assignment": "off",
         "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/unbound-method": "off",
       },
     },
     Object {

--- a/src/configs/eslint/config.ts
+++ b/src/configs/eslint/config.ts
@@ -194,6 +194,7 @@ function customizeLanguage(language?: Language) {
             '@typescript-eslint/no-explicit-any': 'off',
             '@typescript-eslint/no-var-requires': 'off',
             '@typescript-eslint/no-unsafe-assignment': 'off',
+            '@typescript-eslint/unbound-method': 'off',
           },
         },
         ...sharedOverrides,
@@ -303,6 +304,9 @@ function customizeFramework(frameworks?: Framework[]) {
             axe: true,
           },
           env: { 'jest/globals': true },
+          rules: {
+            'jest/unbound-method': 'error',
+          },
         },
       ],
     },


### PR DESCRIPTION
Addresses https://github.com/sumup/ze-dashboard/pull/5395/files#r802550229.

## Purpose

ESLint complains about mocked methods being unbound in spec files.

## Approach and changes

- Disable the two "unbound method" rules in spec files

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
