### PR TITLE
feat: add ESLint plugin for browser compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,15 @@
   "engines": {
     "node": ">=16 || ^14.17"
   },
+  "browserslist": [
+    "chrome >= 57",
+    "firefox >= 54",
+    "safari >= 10.3",
+    "edge >= 16",
+    "opera >= 44",
+    "samsung >= 6.2",
+    "supports css-grid and supports object-entries"
+  ],
   "dependencies": {
     "@babel/core": "^7.17.8",
     "@babel/eslint-parser": "^7.14.3",
@@ -46,6 +55,7 @@
     "eslint-config-airbnb-typescript": "^16.1.3",
     "eslint-config-prettier": "^8.5.0",
     "eslint-formatter-github": "^1.0.11",
+    "eslint-plugin-compat": "^4.0.2",
     "eslint-plugin-cypress": "^2.8.1",
     "eslint-plugin-import": "^2.0.0",
     "eslint-plugin-jest": "^26.1.1",

--- a/src/configs/eslint/__snapshots__/config.spec.ts.snap
+++ b/src/configs/eslint/__snapshots__/config.spec.ts.snap
@@ -13,6 +13,7 @@ Object {
     "eslint:recommended",
     "plugin:prettier/recommended",
     "airbnb-base",
+    "plugin:compat/recommended",
   ],
   "overrides": Array [
     Object {
@@ -126,6 +127,7 @@ Object {
         ],
       },
     },
+    "lintAllEsApis": true,
   },
 }
 `;
@@ -143,6 +145,7 @@ Object {
     "eslint:recommended",
     "plugin:prettier/recommended",
     "airbnb-base",
+    "plugin:compat/recommended",
   ],
   "overrides": Array [
     Object {
@@ -247,6 +250,7 @@ Object {
         ],
       },
     },
+    "lintAllEsApis": true,
   },
 }
 `;
@@ -264,6 +268,7 @@ Object {
     "eslint:recommended",
     "plugin:prettier/recommended",
     "airbnb-base",
+    "plugin:compat/recommended",
   ],
   "overrides": Array [
     Object {
@@ -397,6 +402,7 @@ Object {
         ],
       },
     },
+    "lintAllEsApis": true,
   },
 }
 `;
@@ -414,6 +420,7 @@ Object {
     "eslint:recommended",
     "plugin:prettier/recommended",
     "airbnb-base",
+    "plugin:compat/recommended",
     "plugin:react/recommended",
     "plugin:jsx-a11y/recommended",
   ],
@@ -520,6 +527,7 @@ Object {
         ],
       },
     },
+    "lintAllEsApis": true,
     "react": Object {
       "version": "detect",
     },
@@ -540,6 +548,7 @@ Object {
     "eslint:recommended",
     "plugin:prettier/recommended",
     "airbnb-base",
+    "plugin:compat/recommended",
   ],
   "overrides": Array [
     Object {
@@ -651,6 +660,7 @@ Object {
         ],
       },
     },
+    "lintAllEsApis": true,
   },
 }
 `;
@@ -1413,6 +1423,7 @@ Object {
     "eslint:recommended",
     "plugin:prettier/recommended",
     "airbnb-base",
+    "plugin:compat/recommended",
   ],
   "overrides": Array [
     Object {
@@ -1637,6 +1648,7 @@ Object {
         ],
       },
     },
+    "lintAllEsApis": true,
   },
 }
 `;
@@ -1654,6 +1666,7 @@ Object {
     "eslint:recommended",
     "plugin:prettier/recommended",
     "airbnb-base",
+    "plugin:compat/recommended",
   ],
   "overrides": Array [
     Object {
@@ -1869,6 +1882,7 @@ Object {
         ],
       },
     },
+    "lintAllEsApis": true,
   },
 }
 `;
@@ -1886,6 +1900,7 @@ Object {
     "eslint:recommended",
     "plugin:prettier/recommended",
     "airbnb-base",
+    "plugin:compat/recommended",
   ],
   "overrides": Array [
     Object {
@@ -2130,6 +2145,7 @@ Object {
         ],
       },
     },
+    "lintAllEsApis": true,
   },
 }
 `;
@@ -2147,6 +2163,7 @@ Object {
     "eslint:recommended",
     "plugin:prettier/recommended",
     "airbnb-base",
+    "plugin:compat/recommended",
     "plugin:react/recommended",
     "plugin:jsx-a11y/recommended",
   ],
@@ -2364,6 +2381,7 @@ Object {
         ],
       },
     },
+    "lintAllEsApis": true,
     "react": Object {
       "version": "detect",
     },
@@ -2384,6 +2402,7 @@ Object {
     "eslint:recommended",
     "plugin:prettier/recommended",
     "airbnb-base",
+    "plugin:compat/recommended",
   ],
   "overrides": Array [
     Object {
@@ -2606,6 +2625,7 @@ Object {
         ],
       },
     },
+    "lintAllEsApis": true,
   },
 }
 `;

--- a/src/configs/eslint/config.ts
+++ b/src/configs/eslint/config.ts
@@ -213,7 +213,9 @@ function customizeLanguage(language?: Language) {
 function customizeEnv(environments?: Environment[]) {
   const environmentMap = {
     [Environment.BROWSER]: {
+      extends: ['plugin:compat/recommended'],
       env: { browser: true },
+      settings: { lintAllEsApis: true },
     },
     [Environment.NODE]: {
       extends: ['plugin:node/recommended'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5999,9 +5999,9 @@ minimist-options@4.1.0:
     kind-of "^6.0.3"
 
 minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minipass-collect@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -564,6 +564,16 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@mdn/browser-compat-data@^3.3.14":
+  version "3.3.14"
+  resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-3.3.14.tgz#b72a37c654e598f9ae6f8335faaee182bebc6b28"
+  integrity sha512-n2RC9d6XatVbWFdHLimzzUJxJ1KY8LdjqrW6YvGPiRmsHkhOUx74/Ct10x5Yo7bC/Jvqx7cDEW8IMPv/+vwEzA==
+
+"@mdn/browser-compat-data@^4.1.5":
+  version "4.1.13"
+  resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-4.1.13.tgz#40303f692fff93abe7a0f5782432ec717af9b280"
+  integrity sha512-OFTriJmUcXnA1RjfKDJOfEmhHO44OV7Gxpqnh7eOM+3qep64Yt+uNF4jEeIFHnwTFH5tMcnBQxEI91dXDGiGYQ==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -1636,6 +1646,13 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
+ast-metadata-inferer@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/ast-metadata-inferer/-/ast-metadata-inferer-0.7.0.tgz#c45d874cbdecabea26dc5de11fc6fa1919807c66"
+  integrity sha512-OkMLzd8xelb3gmnp6ToFvvsHLtS6CbagTkFQvQ+ZYFe3/AIl9iKikNR9G7pY3GfOR/2Xc222hwBjzI7HLkE76Q==
+  dependencies:
+    "@mdn/browser-compat-data" "^3.3.14"
+
 ast-types-flow@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
@@ -1853,6 +1870,17 @@ browser-process-hrtime@^1.0.0:
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
+browserslist@^4.16.8:
+  version "4.20.2"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.20.2.tgz#567b41508757ecd904dab4d1c646c612cd3d4f88"
+  integrity sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==
+  dependencies:
+    caniuse-lite "^1.0.30001317"
+    electron-to-chromium "^1.4.84"
+    escalade "^3.1.1"
+    node-releases "^2.0.2"
+    picocolors "^1.0.0"
+
 browserslist@^4.17.5:
   version "4.19.1"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.19.1.tgz#4ac0435b35ab655896c31d53018b6dd5e9e4c9a3"
@@ -1989,6 +2017,11 @@ caniuse-lite@^1.0.30001286:
   version "1.0.30001311"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001311.tgz#682ef3f4e617f1a177ad943de59775ed3032e511"
   integrity sha512-mleTFtFKfykEeW34EyfhGIFjGCqzhh38Y0LhdQ9aWF+HorZTtdgKV/1hEE0NlFkG2ubvisPV6l400tlbPys98A==
+
+caniuse-lite@^1.0.30001304, caniuse-lite@^1.0.30001317:
+  version "1.0.30001320"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001320.tgz#8397391bec389b8ccce328636499b7284ee13285"
+  integrity sha512-MWPzG54AGdo3nWx7zHZTefseM5Y1ccM7hlQKHRqJkPozUaw3hNbBTMmLn16GG2FUzjR13Cr3NPfhIieX5PzXDA==
 
 cardinal@^2.1.1:
   version "2.1.1"
@@ -2410,6 +2443,11 @@ core-js-pure@^3.0.0:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.11.0.tgz#e07f25a8f616d178ec16b0354b008ad28b20b2f0"
   integrity sha512-PxEiQGjzC+5qbvE7ZIs5Zn6BynNeZO9zHhrrWmkRff2SZLq0CE/H5LuZOJHhmOQ8L38+eMzEHAmPYWrUtDfuDQ==
 
+core-js@^3.16.2:
+  version "3.21.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.21.1.tgz#f2e0ddc1fc43da6f904706e8e955bc19d06a0d94"
+  integrity sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==
+
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -2756,6 +2794,11 @@ electron-to-chromium@^1.4.17:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.68.tgz#d79447b6bd1bec9183f166bb33d4bef0d5e4e568"
   integrity sha512-cId+QwWrV8R1UawO6b9BR1hnkJ4EJPCPAr4h315vliHUtVUJDk39Sg1PMNnaWKfj5x+93ssjeJ9LKL6r8LaMiA==
 
+electron-to-chromium@^1.4.84:
+  version "1.4.92"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.92.tgz#88996e9aceb3a500710fd439abfa89b6cc1ac56c"
+  integrity sha512-YAVbvQIcDE/IJ/vzDMjD484/hsRbFPW2qXJPaYTfOhtligmfYEYOep+5QojpaEU9kq6bMvNeC2aG7arYvTHYsA==
+
 elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
@@ -2940,6 +2983,20 @@ eslint-module-utils@^2.7.2:
   dependencies:
     debug "^3.2.7"
     find-up "^2.1.0"
+
+eslint-plugin-compat@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-compat/-/eslint-plugin-compat-4.0.2.tgz#b058627a7d25d352adf0ec16dca8fcf92d9c7af7"
+  integrity sha512-xqvoO54CLTVaEYGMzhu35Wzwk/As7rCvz/2dqwnFiWi0OJccEtGIn+5qq3zqIu9nboXlpdBN579fZcItC73Ycg==
+  dependencies:
+    "@mdn/browser-compat-data" "^4.1.5"
+    ast-metadata-inferer "^0.7.0"
+    browserslist "^4.16.8"
+    caniuse-lite "^1.0.30001304"
+    core-js "^3.16.2"
+    find-up "^5.0.0"
+    lodash.memoize "4.1.2"
+    semver "7.3.5"
 
 eslint-plugin-cypress@^2.8.1:
   version "2.12.1"
@@ -5616,7 +5673,7 @@ lodash.isstring@^4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
   integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
 
-lodash.memoize@4.x:
+lodash.memoize@4.1.2, lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
@@ -6168,7 +6225,7 @@ node-plop@^0.26.3:
     mkdirp "^0.5.1"
     resolve "^1.12.0"
 
-node-releases@^2.0.1:
+node-releases@^2.0.1, node-releases@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.2.tgz#7139fe71e2f4f11b47d4d2986aaf8c48699e0c01"
   integrity sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==
@@ -7551,7 +7608,7 @@ semver-regex@^3.1.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@7.x, semver@^7.0.0, semver@^7.1.1, semver@^7.1.2, semver@^7.1.3, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
+semver@7.3.5, semver@7.x, semver@^7.0.0, semver@^7.1.1, semver@^7.1.2, semver@^7.1.3, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==


### PR DESCRIPTION
## Purpose

In the [RFC to drop support for legacy browsers](https://sumupteam.atlassian.net/wiki/spaces/DEV/pages/2786787641/RFC+Dropping+support+for+legacy+browsers#Ensuring-future-browser-compatibility) (internal link), I wrote:

> In the past, developers have accidentally and unknowingly broken compatibility with legacy browsers causing the application to crash and show a blank screen. Error tracking can help here, but at that point, it’s already too late. It would be better if we could catch compatibility issues before they’re even committed.
> 
> Enter [eslint-plugin-compat](https://github.com/amilajack/eslint-plugin-compat) and [stylelint-no-unsupported-browser-features](https://www.npmjs.com/package/stylelint-no-unsupported-browser-features). These lint JavaScript and CSS respectively and warn about unsupported features. They integrate with [browserlist](https://github.com/browserslist/browserslist), a library to share target browsers between tools. 
> 
> I propose to integrate these plugins and configs into [Foundry](https://github.com/sumup-oss/foundry) to ensure consistency between all of our frontend applications.

This pull request integrates `eslint-plugin-compat`.

## Approach and changes

- Enable the `eslint-plugin-compat` plugin in browser environments

## Todo

- [ ] Test in a real application
- [ ] Document how to configure polyfills

## Definition of done

- [ ] Development completed
- [ ] Reviewers assigned
- [ ] Unit and integration tests
