### PR TITLE
feat(eslint): enable all recommended React hook rules

### DIFF
--- a/src/configs/eslint/__snapshots__/config.spec.ts.snap
+++ b/src/configs/eslint/__snapshots__/config.spec.ts.snap
@@ -550,6 +550,7 @@ Object {
     "airbnb-base",
     "plugin:compat/recommended",
     "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",
   ],
   "overrides": Array [
@@ -641,8 +642,6 @@ Object {
     "object-curly-newline": "off",
     "operator-linebreak": "off",
     "quote-props": "off",
-    "react-hooks/exhaustive-deps": "warn",
-    "react-hooks/rules-of-hooks": "error",
   },
   "settings": Object {
     "import/resolver": Object {
@@ -1407,6 +1406,7 @@ Object {
     "airbnb-base",
     "plugin:node/recommended",
     "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",
   ],
   "overrides": Array [
@@ -1515,8 +1515,6 @@ Object {
     "object-curly-newline": "off",
     "operator-linebreak": "off",
     "quote-props": "off",
-    "react-hooks/exhaustive-deps": "warn",
-    "react-hooks/rules-of-hooks": "error",
   },
   "settings": Object {
     "import/resolver": Object {
@@ -2676,6 +2674,7 @@ Object {
     "airbnb-base",
     "plugin:compat/recommended",
     "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",
   ],
   "overrides": Array [
@@ -2878,8 +2877,6 @@ Object {
     "object-curly-newline": "off",
     "operator-linebreak": "off",
     "quote-props": "off",
-    "react-hooks/exhaustive-deps": "warn",
-    "react-hooks/rules-of-hooks": "error",
   },
   "settings": Object {
     "import/resolver": Object {
@@ -4199,6 +4196,7 @@ Object {
     "airbnb-base",
     "plugin:node/recommended",
     "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",
   ],
   "overrides": Array [
@@ -4418,8 +4416,6 @@ Object {
     "object-curly-newline": "off",
     "operator-linebreak": "off",
     "quote-props": "off",
-    "react-hooks/exhaustive-deps": "warn",
-    "react-hooks/rules-of-hooks": "error",
   },
   "settings": Object {
     "import/resolver": Object {

--- a/src/configs/eslint/config.ts
+++ b/src/configs/eslint/config.ts
@@ -261,12 +261,12 @@ function customizeEnv(environments?: Environment[]) {
 function customizeFramework(frameworks?: Framework[]) {
   const frameworkMap = {
     [Framework.REACT]: {
-      extends: ['plugin:react/recommended', 'plugin:jsx-a11y/recommended'],
+      extends: [
+        'plugin:react/recommended',
+        'plugin:react-hooks/recommended',
+        'plugin:jsx-a11y/recommended',
+      ],
       plugins: ['react', 'react-hooks', 'jsx-a11y'],
-      rules: {
-        'react-hooks/rules-of-hooks': 'error',
-        'react-hooks/exhaustive-deps': 'warn',
-      },
       parserOptions: { ecmaFeatures: { jsx: true } },
       settings: { react: { version: 'detect' } },
     },


### PR DESCRIPTION
## Purpose

The `react-hooks/exhaustive-deps` was treated as a warning so far and thus ignored by developers. This is a [bad](https://typeofnan.dev/you-probably-shouldnt-ignore-react-hooks-exhaustive-deps-warnings/) [idea](https://dev.to/wkrueger/never-ignore-the-exhaustive-deps-rule-2ap8).

## Approach and changes

- Enable all recommended React hook rules as errors

BREAKING CHANGE: Missing dependencies of React hooks are now treated as an ESLint error.

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
