### PR TITLE
feat(eslint): add preset for Next.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,12 +117,12 @@ The preset includes the following tools:
 
 ESLint's configuration options:
 
-| Name         | Type    | Options                                                                | Default      |
-| ------------ | ------- | ---------------------------------------------------------------------- | ------------ |
-| language     | string  | 'TypeScript', 'JavaScript'                                             | 'TypeScript' |
-| environments | array   | 'Browser', 'Node'                                                      | []           |
-| frameworks   | array   | 'React', 'Emotion', 'Jest', 'Testing Library', 'Cypress', 'Playwright' | []           |
-| openSource   | boolean | true, false                                                            | false        |
+| Name         | Type    | Options                                                                           | Default      |
+| ------------ | ------- | --------------------------------------------------------------------------------- | ------------ |
+| language     | string  | 'TypeScript', 'JavaScript'                                                        | 'TypeScript' |
+| environments | array   | 'Browser', 'Node'                                                                 | []           |
+| frameworks   | array   | 'React', 'Next.js', 'Emotion', 'Jest', 'Testing Library', 'Cypress', 'Playwright' | []           |
+| openSource   | boolean | true, false                                                                       | false        |
 
 #### Prettier
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@babel/core": "^7.17.8",
     "@babel/eslint-parser": "^7.14.3",
     "@emotion/eslint-plugin": "^11.7.0",
+    "@next/eslint-plugin-next": "^12.1.6",
     "@semantic-release/commit-analyzer": "^9.0.2",
     "@semantic-release/github": "^8.0.2",
     "@semantic-release/npm": "^9.0.1",

--- a/src/configs/eslint/__snapshots__/config.spec.ts.snap
+++ b/src/configs/eslint/__snapshots__/config.spec.ts.snap
@@ -411,6 +411,124 @@ Object {
 exports[`eslint with options should return a config for {
   language: 'JavaScript',
   environments: [ 'Browser', [length]: 1 ],
+  frameworks: [ 'Next.js', [length]: 1 ]
+} 1`] = `
+Object {
+  "env": Object {
+    "browser": true,
+  },
+  "extends": Array [
+    "eslint:recommended",
+    "plugin:prettier/recommended",
+    "airbnb-base",
+    "plugin:compat/recommended",
+    "plugin:@next/next/recommended",
+  ],
+  "overrides": Array [
+    Object {
+      "extends": Array [
+        "plugin:json/recommended",
+      ],
+      "files": Array [
+        "**/*.json",
+      ],
+      "rules": Object {
+        "notice/notice": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "**/*.{story,stories}.*",
+      ],
+      "rules": Object {
+        "import/no-extraneous-dependencies": "off",
+        "no-alert": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "**/*spec.*",
+        "**/jest*",
+        "**/setupTests.*",
+        "**/test-utils.*",
+      ],
+      "rules": Object {
+        "import/no-extraneous-dependencies": "off",
+        "react/display-name": "off",
+        "react/prop-types": "off",
+      },
+    },
+  ],
+  "parser": "@babel/eslint-parser",
+  "parserOptions": Object {
+    "allowImportExportEverywhere": true,
+    "ecmaFeatures": Object {
+      "impliedStrict": true,
+      "modules": true,
+    },
+    "ecmaVersion": 6,
+    "sourceType": "module",
+  },
+  "plugins": Array [
+    "prettier",
+  ],
+  "root": true,
+  "rules": Object {
+    "comma-dangle": "off",
+    "curly": Array [
+      "error",
+      "all",
+    ],
+    "function-paren-newline": "off",
+    "implicit-arrow-linebreak": "off",
+    "import/extensions": "off",
+    "import/order": Array [
+      "error",
+      Object {
+        "newlines-between": "always",
+      },
+    ],
+    "import/prefer-default-export": "off",
+    "indent": "off",
+    "max-len": Array [
+      "error",
+      Object {
+        "code": 80,
+        "ignoreComments": true,
+        "ignorePattern": "^(?:import\\\\s|export\\\\s|\\\\s*it(?:\\\\.(?:skip|only))?\\\\()",
+        "ignoreRegExpLiterals": true,
+        "ignoreStrings": true,
+        "ignoreTemplateLiterals": true,
+        "ignoreUrls": true,
+        "tabWidth": 2,
+      },
+    ],
+    "no-confusing-arrow": "off",
+    "no-underscore-dangle": "error",
+    "no-use-before-define": "off",
+    "object-curly-newline": "off",
+    "operator-linebreak": "off",
+    "quote-props": "off",
+  },
+  "settings": Object {
+    "import/resolver": Object {
+      "node": Object {
+        "extensions": Array [
+          ".js",
+          ".jsx",
+          ".ts",
+          ".tsx",
+        ],
+      },
+    },
+    "lintAllEsApis": true,
+  },
+}
+`;
+
+exports[`eslint with options should return a config for {
+  language: 'JavaScript',
+  environments: [ 'Browser', [length]: 1 ],
   frameworks: [ 'Playwright', [length]: 1 ]
 } 1`] = `
 Object {
@@ -1252,6 +1370,140 @@ Object {
 exports[`eslint with options should return a config for {
   language: 'JavaScript',
   environments: [ 'Node', [length]: 1 ],
+  frameworks: [ 'Next.js', [length]: 1 ]
+} 1`] = `
+Object {
+  "env": Object {
+    "node": true,
+  },
+  "extends": Array [
+    "eslint:recommended",
+    "plugin:prettier/recommended",
+    "airbnb-base",
+    "plugin:node/recommended",
+    "plugin:@next/next/recommended",
+  ],
+  "overrides": Array [
+    Object {
+      "extends": Array [
+        "plugin:json/recommended",
+      ],
+      "files": Array [
+        "**/*.json",
+      ],
+      "rules": Object {
+        "notice/notice": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "**/*.{story,stories}.*",
+      ],
+      "rules": Object {
+        "import/no-extraneous-dependencies": "off",
+        "no-alert": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "**/*spec.*",
+        "**/jest*",
+        "**/setupTests.*",
+        "**/test-utils.*",
+      ],
+      "rules": Object {
+        "import/no-extraneous-dependencies": "off",
+        "react/display-name": "off",
+        "react/prop-types": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "**/*.spec.*",
+        "**/jest*",
+        "**/setupTests.*",
+        "**/test-utils.*",
+      ],
+      "rules": Object {
+        "node/no-extraneous-require": "off",
+        "node/no-missing-require": "off",
+        "node/no-unpublished-import": "off",
+        "node/no-unpublished-require": "off",
+      },
+    },
+  ],
+  "parser": "@babel/eslint-parser",
+  "parserOptions": Object {
+    "allowImportExportEverywhere": true,
+    "ecmaFeatures": Object {
+      "impliedStrict": true,
+      "modules": true,
+    },
+    "ecmaVersion": 6,
+    "sourceType": "module",
+  },
+  "plugins": Array [
+    "prettier",
+  ],
+  "root": true,
+  "rules": Object {
+    "comma-dangle": "off",
+    "curly": Array [
+      "error",
+      "all",
+    ],
+    "function-paren-newline": "off",
+    "implicit-arrow-linebreak": "off",
+    "import/extensions": "off",
+    "import/order": Array [
+      "error",
+      Object {
+        "newlines-between": "always",
+      },
+    ],
+    "import/prefer-default-export": "off",
+    "indent": "off",
+    "max-len": Array [
+      "error",
+      Object {
+        "code": 80,
+        "ignoreComments": true,
+        "ignorePattern": "^(?:import\\\\s|export\\\\s|\\\\s*it(?:\\\\.(?:skip|only))?\\\\()",
+        "ignoreRegExpLiterals": true,
+        "ignoreStrings": true,
+        "ignoreTemplateLiterals": true,
+        "ignoreUrls": true,
+        "tabWidth": 2,
+      },
+    ],
+    "no-confusing-arrow": "off",
+    "no-underscore-dangle": "error",
+    "no-use-before-define": "off",
+    "node/no-extraneous-import": "off",
+    "node/no-missing-import": "off",
+    "node/no-unsupported-features/es-syntax": "off",
+    "object-curly-newline": "off",
+    "operator-linebreak": "off",
+    "quote-props": "off",
+  },
+  "settings": Object {
+    "import/resolver": Object {
+      "node": Object {
+        "extensions": Array [
+          ".js",
+          ".jsx",
+          ".ts",
+          ".tsx",
+        ],
+      },
+    },
+  },
+}
+`;
+
+exports[`eslint with options should return a config for {
+  language: 'JavaScript',
+  environments: [ 'Node', [length]: 1 ],
   frameworks: [ 'Playwright', [length]: 1 ]
 } 1`] = `
 Object {
@@ -2426,6 +2678,235 @@ Object {
 exports[`eslint with options should return a config for {
   language: 'TypeScript',
   environments: [ 'Browser', [length]: 1 ],
+  frameworks: [ 'Next.js', [length]: 1 ]
+} 1`] = `
+Object {
+  "env": Object {
+    "browser": true,
+  },
+  "extends": Array [
+    "eslint:recommended",
+    "plugin:prettier/recommended",
+    "airbnb-base",
+    "plugin:compat/recommended",
+    "plugin:@next/next/recommended",
+  ],
+  "overrides": Array [
+    Object {
+      "extends": Array [
+        "plugin:json/recommended",
+      ],
+      "files": Array [
+        "**/*.json",
+      ],
+      "rules": Object {
+        "notice/notice": "off",
+      },
+    },
+    Object {
+      "extends": Array [
+        "airbnb-typescript/base",
+        "plugin:@typescript-eslint/eslint-recommended",
+        "plugin:@typescript-eslint/recommended",
+        "plugin:@typescript-eslint/recommended-requiring-type-checking",
+      ],
+      "files": Array [
+        "**/*.{ts,tsx}",
+      ],
+      "parser": "@typescript-eslint/parser",
+      "parserOptions": Object {
+        "ecmaFeatures": Object {
+          "modules": true,
+        },
+        "ecmaVersion": 6,
+        "extraFileExtensions": Array [
+          ".json",
+        ],
+        "project": Array [
+          "./tsconfig.json",
+        ],
+        "sourceType": "module",
+        "tsconfigRootDir": "/project/dir",
+      },
+      "plugins": Array [
+        "@typescript-eslint",
+      ],
+      "rules": Object {
+        "@typescript-eslint/explicit-function-return-type": "off",
+        "@typescript-eslint/indent": "off",
+        "@typescript-eslint/no-use-before-define": Array [
+          "error",
+          Object {
+            "functions": false,
+          },
+        ],
+        "comma-dangle": "off",
+        "curly": Array [
+          "error",
+          "all",
+        ],
+        "function-paren-newline": "off",
+        "implicit-arrow-linebreak": "off",
+        "import/extensions": "off",
+        "import/order": Array [
+          "error",
+          Object {
+            "newlines-between": "always",
+          },
+        ],
+        "import/prefer-default-export": "off",
+        "indent": "off",
+        "max-len": Array [
+          "error",
+          Object {
+            "code": 80,
+            "ignoreComments": true,
+            "ignorePattern": "^(?:import\\\\s|export\\\\s|\\\\s*it(?:\\\\.(?:skip|only))?\\\\()",
+            "ignoreRegExpLiterals": true,
+            "ignoreStrings": true,
+            "ignoreTemplateLiterals": true,
+            "ignoreUrls": true,
+            "tabWidth": 2,
+          },
+        ],
+        "no-confusing-arrow": "off",
+        "no-underscore-dangle": "error",
+        "no-use-before-define": "off",
+        "object-curly-newline": "off",
+        "operator-linebreak": "off",
+        "quote-props": "off",
+        "react/prop-types": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "**/*.d.ts",
+      ],
+      "rules": Object {
+        "import/no-extraneous-dependencies": Array [
+          "error",
+          Object {
+            "devDependencies": true,
+          },
+        ],
+        "node/no-extraneous-import": "off",
+        "spaced-comment": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "**/*.{story,stories}.{ts,tsx}",
+      ],
+      "rules": Object {
+        "@typescript-eslint/explicit-module-boundary-types": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "**/*spec.{ts,tsx}",
+        "**/setupTests.{ts,tsx}",
+        "**/test-utils.{ts,tsx}",
+      ],
+      "rules": Object {
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/unbound-method": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "**/*.{story,stories}.*",
+      ],
+      "rules": Object {
+        "import/no-extraneous-dependencies": "off",
+        "no-alert": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "**/*spec.*",
+        "**/jest*",
+        "**/setupTests.*",
+        "**/test-utils.*",
+      ],
+      "rules": Object {
+        "import/no-extraneous-dependencies": "off",
+        "react/display-name": "off",
+        "react/prop-types": "off",
+      },
+    },
+  ],
+  "parser": "@babel/eslint-parser",
+  "parserOptions": Object {
+    "allowImportExportEverywhere": true,
+    "ecmaFeatures": Object {
+      "impliedStrict": true,
+      "modules": true,
+    },
+    "ecmaVersion": 6,
+    "sourceType": "module",
+  },
+  "plugins": Array [
+    "prettier",
+  ],
+  "root": true,
+  "rules": Object {
+    "comma-dangle": "off",
+    "curly": Array [
+      "error",
+      "all",
+    ],
+    "function-paren-newline": "off",
+    "implicit-arrow-linebreak": "off",
+    "import/extensions": "off",
+    "import/order": Array [
+      "error",
+      Object {
+        "newlines-between": "always",
+      },
+    ],
+    "import/prefer-default-export": "off",
+    "indent": "off",
+    "max-len": Array [
+      "error",
+      Object {
+        "code": 80,
+        "ignoreComments": true,
+        "ignorePattern": "^(?:import\\\\s|export\\\\s|\\\\s*it(?:\\\\.(?:skip|only))?\\\\()",
+        "ignoreRegExpLiterals": true,
+        "ignoreStrings": true,
+        "ignoreTemplateLiterals": true,
+        "ignoreUrls": true,
+        "tabWidth": 2,
+      },
+    ],
+    "no-confusing-arrow": "off",
+    "no-underscore-dangle": "error",
+    "no-use-before-define": "off",
+    "object-curly-newline": "off",
+    "operator-linebreak": "off",
+    "quote-props": "off",
+  },
+  "settings": Object {
+    "import/resolver": Object {
+      "node": Object {
+        "extensions": Array [
+          ".js",
+          ".jsx",
+          ".ts",
+          ".tsx",
+        ],
+      },
+    },
+    "lintAllEsApis": true,
+  },
+}
+`;
+
+exports[`eslint with options should return a config for {
+  language: 'TypeScript',
+  environments: [ 'Browser', [length]: 1 ],
   frameworks: [ 'Playwright', [length]: 1 ]
 } 1`] = `
 Object {
@@ -3858,6 +4339,251 @@ Object {
       ],
       "rules": Object {
         "jest/unbound-method": "error",
+      },
+    },
+  ],
+  "parser": "@babel/eslint-parser",
+  "parserOptions": Object {
+    "allowImportExportEverywhere": true,
+    "ecmaFeatures": Object {
+      "impliedStrict": true,
+      "modules": true,
+    },
+    "ecmaVersion": 6,
+    "sourceType": "module",
+  },
+  "plugins": Array [
+    "prettier",
+  ],
+  "root": true,
+  "rules": Object {
+    "comma-dangle": "off",
+    "curly": Array [
+      "error",
+      "all",
+    ],
+    "function-paren-newline": "off",
+    "implicit-arrow-linebreak": "off",
+    "import/extensions": "off",
+    "import/order": Array [
+      "error",
+      Object {
+        "newlines-between": "always",
+      },
+    ],
+    "import/prefer-default-export": "off",
+    "indent": "off",
+    "max-len": Array [
+      "error",
+      Object {
+        "code": 80,
+        "ignoreComments": true,
+        "ignorePattern": "^(?:import\\\\s|export\\\\s|\\\\s*it(?:\\\\.(?:skip|only))?\\\\()",
+        "ignoreRegExpLiterals": true,
+        "ignoreStrings": true,
+        "ignoreTemplateLiterals": true,
+        "ignoreUrls": true,
+        "tabWidth": 2,
+      },
+    ],
+    "no-confusing-arrow": "off",
+    "no-underscore-dangle": "error",
+    "no-use-before-define": "off",
+    "node/no-extraneous-import": "off",
+    "node/no-missing-import": "off",
+    "node/no-unsupported-features/es-syntax": "off",
+    "object-curly-newline": "off",
+    "operator-linebreak": "off",
+    "quote-props": "off",
+  },
+  "settings": Object {
+    "import/resolver": Object {
+      "node": Object {
+        "extensions": Array [
+          ".js",
+          ".jsx",
+          ".ts",
+          ".tsx",
+        ],
+      },
+    },
+  },
+}
+`;
+
+exports[`eslint with options should return a config for {
+  language: 'TypeScript',
+  environments: [ 'Node', [length]: 1 ],
+  frameworks: [ 'Next.js', [length]: 1 ]
+} 1`] = `
+Object {
+  "env": Object {
+    "node": true,
+  },
+  "extends": Array [
+    "eslint:recommended",
+    "plugin:prettier/recommended",
+    "airbnb-base",
+    "plugin:node/recommended",
+    "plugin:@next/next/recommended",
+  ],
+  "overrides": Array [
+    Object {
+      "extends": Array [
+        "plugin:json/recommended",
+      ],
+      "files": Array [
+        "**/*.json",
+      ],
+      "rules": Object {
+        "notice/notice": "off",
+      },
+    },
+    Object {
+      "extends": Array [
+        "airbnb-typescript/base",
+        "plugin:@typescript-eslint/eslint-recommended",
+        "plugin:@typescript-eslint/recommended",
+        "plugin:@typescript-eslint/recommended-requiring-type-checking",
+      ],
+      "files": Array [
+        "**/*.{ts,tsx}",
+      ],
+      "parser": "@typescript-eslint/parser",
+      "parserOptions": Object {
+        "ecmaFeatures": Object {
+          "modules": true,
+        },
+        "ecmaVersion": 6,
+        "extraFileExtensions": Array [
+          ".json",
+        ],
+        "project": Array [
+          "./tsconfig.json",
+        ],
+        "sourceType": "module",
+        "tsconfigRootDir": "/project/dir",
+      },
+      "plugins": Array [
+        "@typescript-eslint",
+      ],
+      "rules": Object {
+        "@typescript-eslint/explicit-function-return-type": "off",
+        "@typescript-eslint/indent": "off",
+        "@typescript-eslint/no-use-before-define": Array [
+          "error",
+          Object {
+            "functions": false,
+          },
+        ],
+        "comma-dangle": "off",
+        "curly": Array [
+          "error",
+          "all",
+        ],
+        "function-paren-newline": "off",
+        "implicit-arrow-linebreak": "off",
+        "import/extensions": "off",
+        "import/order": Array [
+          "error",
+          Object {
+            "newlines-between": "always",
+          },
+        ],
+        "import/prefer-default-export": "off",
+        "indent": "off",
+        "max-len": Array [
+          "error",
+          Object {
+            "code": 80,
+            "ignoreComments": true,
+            "ignorePattern": "^(?:import\\\\s|export\\\\s|\\\\s*it(?:\\\\.(?:skip|only))?\\\\()",
+            "ignoreRegExpLiterals": true,
+            "ignoreStrings": true,
+            "ignoreTemplateLiterals": true,
+            "ignoreUrls": true,
+            "tabWidth": 2,
+          },
+        ],
+        "no-confusing-arrow": "off",
+        "no-underscore-dangle": "error",
+        "no-use-before-define": "off",
+        "object-curly-newline": "off",
+        "operator-linebreak": "off",
+        "quote-props": "off",
+        "react/prop-types": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "**/*.d.ts",
+      ],
+      "rules": Object {
+        "import/no-extraneous-dependencies": Array [
+          "error",
+          Object {
+            "devDependencies": true,
+          },
+        ],
+        "node/no-extraneous-import": "off",
+        "spaced-comment": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "**/*.{story,stories}.{ts,tsx}",
+      ],
+      "rules": Object {
+        "@typescript-eslint/explicit-module-boundary-types": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "**/*spec.{ts,tsx}",
+        "**/setupTests.{ts,tsx}",
+        "**/test-utils.{ts,tsx}",
+      ],
+      "rules": Object {
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/unbound-method": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "**/*.{story,stories}.*",
+      ],
+      "rules": Object {
+        "import/no-extraneous-dependencies": "off",
+        "no-alert": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "**/*spec.*",
+        "**/jest*",
+        "**/setupTests.*",
+        "**/test-utils.*",
+      ],
+      "rules": Object {
+        "import/no-extraneous-dependencies": "off",
+        "react/display-name": "off",
+        "react/prop-types": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "**/*.spec.*",
+        "**/jest*",
+        "**/setupTests.*",
+        "**/test-utils.*",
+      ],
+      "rules": Object {
+        "node/no-extraneous-require": "off",
+        "node/no-missing-require": "off",
+        "node/no-unpublished-import": "off",
+        "node/no-unpublished-require": "off",
       },
     },
   ],

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -51,6 +51,7 @@ export enum Environment {
 
 export enum Framework {
   REACT = 'React',
+  NEXT_JS = 'Next.js',
   EMOTION = 'Emotion',
   JEST = 'Jest',
   TESTING_LIBRARY = 'Testing Library',

--- a/yarn.lock
+++ b/yarn.lock
@@ -574,6 +574,13 @@
   resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-4.1.13.tgz#40303f692fff93abe7a0f5782432ec717af9b280"
   integrity sha512-OFTriJmUcXnA1RjfKDJOfEmhHO44OV7Gxpqnh7eOM+3qep64Yt+uNF4jEeIFHnwTFH5tMcnBQxEI91dXDGiGYQ==
 
+"@next/eslint-plugin-next@^12.1.6":
+  version "12.1.6"
+  resolved "https://registry.yarnpkg.com/@next/eslint-plugin-next/-/eslint-plugin-next-12.1.6.tgz#dde3f98831f15923b25244588d924c716956292e"
+  integrity sha512-yNUtJ90NEiYFT6TJnNyofKMPYqirKDwpahcbxBgSIuABwYOdkGwzos1ZkYD51Qf0diYwpQZBeVqElTk7Q2WNqw==
+  dependencies:
+    glob "7.1.7"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -3763,6 +3770,18 @@ glob-parent@^6.0.1:
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
+
+glob@7.1.7:
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.2.0:
   version "7.2.0"


### PR DESCRIPTION
## Purpose

[Next.js](https://nextjs.org/) has become SumUp's default framework for building React applications.

## Approach and changes

- Add `Next.js` as an option to the frameworks
- Warn when the `Next.js` and `React` framework options are used together as they might conflict.

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
