### PR TITLE
feat: automatically detect used frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@sumup/foundry)](https://www.npmjs.com/package/@sumup/foundry) [![Code coverage](https://img.shields.io/codecov/c/github/sumup-oss/foundry)](https://codecov.io/gh/sumup-oss/foundry) [![License](https://img.shields.io/github/license/sumup-oss/foundry)](https://github.com/sumup-oss/foundry/blob/main/LICENSE) [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.1%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 
-A toolkit that makes it a breeze to set up and maintain JavaScript + TypeScript applications. Foundry has presets for [🔍 linting](#-lint), [🚀 releasing](#-release), [🤖 continuous integration (CI)](#-continuous-integration-ci), and [🖇️ templates](#-templates) and currently supports [React](https://reactjs.org), [Emotion](https://emotion.sh/), [Jest](https://jestjs.io/), [Cypress](https://www.cypress.io/), [Node](https://nodejs.org/en/) and [Testing Library](https://testing-library.com/).
+A toolkit that makes it a breeze to set up and maintain JavaScript + TypeScript applications. Foundry has presets for [🔍 linting](#-lint), [🚀 releasing](#-release), [🤖 continuous integration (CI)](#-continuous-integration-ci), and [🖇️ templates](#-templates) and currently supports [Next.js](https://nextjs.org), [React](https://reactjs.org), [Emotion](https://emotion.sh/), [Jest](https://jestjs.io/), [Testing Library](https://testing-library.com/), [Cypress](https://www.cypress.io/), [Playwright](https://playwright.dev/) and [Node](https://nodejs.org/en/).
 
 </div>
 
@@ -83,11 +83,11 @@ module.exports = require('@sumup/foundry/<tool>')(options, overrides);
 module.exports = require('@sumup/foundry/eslint')(
   {
     language: 'TypeScript',
-    frameworks: ['React', 'Emotion'],
+    environments: ['Browser'],
   },
   {
     rules: {
-      'emotion/jsx-import': 'error',
+      '@emotion/jsx-import': 'error',
     },
   },
 );
@@ -113,16 +113,16 @@ The preset includes the following tools:
 
 #### ESLint
 
-[ESLint](https://www.npmjs.com/package/eslint) identifies and fixes problematic patterns in your JavaScript code so you can spot mistakes early.
+[ESLint](https://www.npmjs.com/package/eslint) identifies and fixes problematic patterns in your code so you can spot mistakes early.
 
 ESLint's configuration options:
 
-| Name         | Type    | Options                                                                           | Default      |
-| ------------ | ------- | --------------------------------------------------------------------------------- | ------------ |
-| language     | string  | 'TypeScript', 'JavaScript'                                                        | 'TypeScript' |
-| environments | array   | 'Browser', 'Node'                                                                 | []           |
-| frameworks   | array   | 'React', 'Next.js', 'Emotion', 'Jest', 'Testing Library', 'Cypress', 'Playwright' | []           |
-| openSource   | boolean | true, false                                                                       | false        |
+| Name         | Type    | Options                                                                           | Default        |
+| ------------ | ------- | --------------------------------------------------------------------------------- | -------------- |
+| language     | string  | 'TypeScript', 'JavaScript'                                                        | 'TypeScript'   |
+| environments | array   | 'Browser', 'Node'                                                                 | []             |
+| frameworks   | array   | 'React', 'Next.js', 'Emotion', 'Jest', 'Testing Library', 'Cypress', 'Playwright' | _autodetected_ |
+| openSource   | boolean | true, false                                                                       | false          |
 
 #### Prettier
 
@@ -259,4 +259,4 @@ If you feel another member of the community violated our CoC or you are experien
 
 ![SumUp logo](https://raw.githubusercontent.com/sumup-oss/assets/master/sumup-logo.svg?sanitize=true)
 
-It is our mission to make easy and fast card payments a reality across the _entire_ world. You can pay with SumUp in more than 30 countries already. Our engineers work in Berlin, Cologne, Sofia, and Sāo Paulo. They write code in JavaScript, Swift, Ruby, Go, Java, Erlang, Elixir, and more. Want to come work with us? [Head to our careers page](https://sumup.com/careers) to find out more.
+It is our mission to make easy and fast card payments a reality across the _entire_ world. You can pay with SumUp in more than 30 countries already. Our engineers work in Berlin, Cologne, Sofia, and Sāo Paulo. They write code in TypeScript, Swift, Ruby, Go, Java, Erlang, Elixir, and more. Want to come work with us? [Head to our careers page](https://sumup.com/careers) to find out more.

--- a/package.json
+++ b/package.json
@@ -77,9 +77,9 @@
     "listr": "^0.14.3",
     "listr-inquirer": "^0.1.0",
     "lodash": "^4.17.11",
-    "pkg-up": "^3.1.0",
     "plop": "^2.1.0",
     "prettier": "^2.6.2",
+    "read-pkg-up": "^7.0.1",
     "semantic-release": "^19.0.2",
     "yargs": "^17.4.1"
   },

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -40,7 +40,12 @@ import {
 } from '../types/shared';
 import * as logger from '../lib/logger';
 import { enumToChoices } from '../lib/choices';
-import { writeFile, addPackageScript, savePackageJson } from '../lib/files';
+import {
+  writeFile,
+  addPackageScript,
+  savePackageJson,
+  detectFrameworks,
+} from '../lib/files';
 import { presets, presetChoices } from '../presets';
 import { tools } from '../configs';
 
@@ -97,6 +102,7 @@ export async function init({ $0, _, ...args }: InitParams): Promise<void> {
         name: 'frameworks',
         message: 'Which framework(s) does the project use?',
         choices: enumToChoices(Framework),
+        default: detectFrameworks,
         when: (): boolean => !args.frameworks,
       },
       [Prompt.CI]: {

--- a/src/configs/eslint/config.spec.ts
+++ b/src/configs/eslint/config.spec.ts
@@ -108,7 +108,7 @@ describe('eslint', () => {
     });
 
     it('should return a config with a copyright notice', () => {
-      const options = { openSource: true };
+      const options = { openSource: true, frameworks: [] };
       const actual = createConfig(options);
       expect(actual).toMatchSnapshot();
     });

--- a/src/configs/eslint/config.ts
+++ b/src/configs/eslint/config.ts
@@ -19,6 +19,7 @@ import { flow, mergeWith, isArray, isObject, isEmpty, uniq } from 'lodash/fp';
 
 import { Options, Language, Environment, Framework } from '../../types/shared';
 import * as logger from '../../lib/logger';
+import { detectFrameworks } from '../../lib/files';
 
 type EslintOptions = Pick<
   Options,
@@ -423,7 +424,7 @@ export function createConfig(
   return flow(
     customizeLanguage(options.language),
     customizeEnv(options.environments),
-    customizeFramework(options.frameworks),
+    customizeFramework(options.frameworks || detectFrameworks()),
     addCopyrightNotice(options.openSource),
     applyOverrides(overrides),
   )(base);

--- a/src/lib/files.spec.ts
+++ b/src/lib/files.spec.ts
@@ -15,14 +15,15 @@
 
 import fs from 'fs';
 
+import { PackageJson } from '../types/shared';
+
 import { writeFile, addPackageScript } from './files';
 
 jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
   writeFile: jest.fn((file, data, options, callback) => callback()),
   mkdirSync: jest.fn(),
-  existsSync: jest.fn(),
-  readFile: jest.fn(),
 }));
 
 const content = 'module.exports = "Hello world"';
@@ -90,7 +91,7 @@ describe('files', () => {
 
   describe('addPackageScript', () => {
     it('should add a script to the package.json file', () => {
-      const packageJson = { scripts: {} };
+      const packageJson = { scripts: {} } as PackageJson;
       const name = 'lint';
       const command = 'foundry run eslint src';
       const shouldOverwrite = false;
@@ -109,7 +110,7 @@ describe('files', () => {
     });
 
     it('should initialize the scripts if they do not exist yet', () => {
-      const packageJson = {};
+      const packageJson = {} as PackageJson;
       const name = 'lint';
       const command = 'foundry run eslint src';
       const shouldOverwrite = false;
@@ -128,7 +129,9 @@ describe('files', () => {
     });
 
     it('should throw an error if a conflicting script exists', () => {
-      const packageJson = { scripts: { lint: 'eslint .' } };
+      const packageJson = {
+        scripts: { lint: 'eslint .' },
+      } as unknown as PackageJson;
       const name = 'lint';
       const command = 'foundry run eslint src';
       const shouldOverwrite = false;
@@ -140,7 +143,9 @@ describe('files', () => {
     });
 
     it('should overwrite the conflicting script', () => {
-      const packageJson = { scripts: { lint: 'eslint .' } };
+      const packageJson = {
+        scripts: { lint: 'eslint .' },
+      } as unknown as PackageJson;
       const name = 'lint';
       const command = 'foundry run eslint src';
       const shouldOverwrite = true;

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -18,7 +18,6 @@ import path from 'path';
 import { promisify } from 'util';
 
 import { format, Options as PrettierConfig } from 'prettier';
-import pkgUp from 'pkg-up';
 
 import { PackageJson } from '../types/shared';
 import prettierConfig from '../prettier';
@@ -59,14 +58,6 @@ export function writeFile(
   return writeFileAsync(filePath, fileContent, { flag });
 }
 
-export async function findPackageJson(): Promise<string> {
-  const packagePath = await pkgUp();
-  if (!packagePath) {
-    throw new Error('Unable to find a "package.json" file.');
-  }
-  return packagePath;
-}
-
 export function addPackageScript(
   packageJson: PackageJson,
   name: string,
@@ -88,8 +79,10 @@ export function addPackageScript(
   return packageJson;
 }
 
-export async function savePackageJson(packageJson: PackageJson): Promise<void> {
-  const packagePath = await findPackageJson();
+export async function savePackageJson(
+  packagePath: string,
+  packageJson: PackageJson,
+): Promise<void> {
   const content = `${JSON.stringify(packageJson, null, 2)}\n`;
   return writeFileAsync(packagePath, content);
 }

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+import type { NormalizedPackageJson } from 'read-pkg-up';
+
 export enum Preset {
   LINT = 'lint',
   RELEASE = 'release',
@@ -92,8 +94,4 @@ export interface ToolOptions {
   scripts?: (options: Options) => Script[];
 }
 
-export type PackageJson = {
-  scripts?: { [key: string]: string };
-  bin?: string;
-  [key: string]: Record<string, unknown> | string | undefined;
-};
+export type PackageJson = NormalizedPackageJson;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3443,13 +3443,6 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
-find-up@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
-  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
-  dependencies:
-    locate-path "^3.0.0"
-
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
@@ -5443,14 +5436,6 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-locate-path@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
-  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
-  dependencies:
-    p-locate "^3.0.0"
-    path-exists "^3.0.0"
-
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -6538,7 +6523,7 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.0.0, p-limit@^2.2.0:
+p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
@@ -6558,13 +6543,6 @@ p-locate@^2.0.0:
   integrity sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
   dependencies:
     p-limit "^1.1.0"
-
-p-locate@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
-  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
-  dependencies:
-    p-limit "^2.0.0"
 
 p-locate@^4.1.0:
   version "4.1.0"
@@ -6824,13 +6802,6 @@ pkg-dir@^5.0.0:
   integrity sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==
   dependencies:
     find-up "^5.0.0"
-
-pkg-up@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-3.1.0.tgz#100ec235cc150e4fd42519412596a28512a0def5"
-  integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
-  dependencies:
-    find-up "^3.0.0"
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
## Purpose

The list of supported frameworks keeps getting longer. It's easy for developers to miss newly added frameworks or forget to update the ESLint config when installing a new framework.

Instead, we can detect the used frameworks based on the installed project dependencies.

## Approach and changes

- Automatically detect frameworks based on the installed dependencies

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
