### PR TITLE
feat(eslint): improve ESLint rules for API routes

### DIFF
--- a/src/configs/eslint/__snapshots__/config.spec.ts.snap
+++ b/src/configs/eslint/__snapshots__/config.spec.ts.snap
@@ -58,6 +58,9 @@ Object {
         "**/*Fixtures.*",
         "**/__fixtures__/**/*",
         "**/__mocks__/**/*",
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
       ],
       "rules": Object {
         "compat/compat": "off",
@@ -214,6 +217,9 @@ Object {
         "**/*Fixtures.*",
         "**/__fixtures__/**/*",
         "**/__mocks__/**/*",
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
       ],
       "rules": Object {
         "compat/compat": "off",
@@ -360,6 +366,9 @@ Object {
         "**/*Fixtures.*",
         "**/__fixtures__/**/*",
         "**/__mocks__/**/*",
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
       ],
       "rules": Object {
         "compat/compat": "off",
@@ -547,6 +556,9 @@ Object {
         "**/*Fixtures.*",
         "**/__fixtures__/**/*",
         "**/__mocks__/**/*",
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
       ],
       "rules": Object {
         "compat/compat": "off",
@@ -734,6 +746,9 @@ Object {
         "**/*Fixtures.*",
         "**/__fixtures__/**/*",
         "**/__mocks__/**/*",
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
       ],
       "rules": Object {
         "compat/compat": "off",
@@ -887,6 +902,9 @@ Object {
         "**/*Fixtures.*",
         "**/__fixtures__/**/*",
         "**/__mocks__/**/*",
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
       ],
       "rules": Object {
         "compat/compat": "off",
@@ -1036,6 +1054,9 @@ Object {
         "**/*Fixtures.*",
         "**/__fixtures__/**/*",
         "**/__mocks__/**/*",
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
       ],
       "rules": Object {
         "compat/compat": "off",
@@ -2447,6 +2468,9 @@ Object {
         "**/*Fixtures.*",
         "**/__fixtures__/**/*",
         "**/__mocks__/**/*",
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
       ],
       "rules": Object {
         "compat/compat": "off",
@@ -2727,6 +2751,9 @@ Object {
         "**/*Fixtures.*",
         "**/__fixtures__/**/*",
         "**/__mocks__/**/*",
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
       ],
       "rules": Object {
         "compat/compat": "off",
@@ -2997,6 +3024,9 @@ Object {
         "**/*Fixtures.*",
         "**/__fixtures__/**/*",
         "**/__mocks__/**/*",
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
       ],
       "rules": Object {
         "compat/compat": "off",
@@ -3308,6 +3338,9 @@ Object {
         "**/*Fixtures.*",
         "**/__fixtures__/**/*",
         "**/__mocks__/**/*",
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
       ],
       "rules": Object {
         "compat/compat": "off",
@@ -3619,6 +3652,9 @@ Object {
         "**/*Fixtures.*",
         "**/__fixtures__/**/*",
         "**/__mocks__/**/*",
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
       ],
       "rules": Object {
         "compat/compat": "off",
@@ -3896,6 +3932,9 @@ Object {
         "**/*Fixtures.*",
         "**/__fixtures__/**/*",
         "**/__mocks__/**/*",
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
       ],
       "rules": Object {
         "compat/compat": "off",
@@ -4169,6 +4208,9 @@ Object {
         "**/*Fixtures.*",
         "**/__fixtures__/**/*",
         "**/__mocks__/**/*",
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
       ],
       "rules": Object {
         "compat/compat": "off",

--- a/src/configs/eslint/__snapshots__/config.spec.ts.snap
+++ b/src/configs/eslint/__snapshots__/config.spec.ts.snap
@@ -29,6 +29,16 @@ Object {
     },
     Object {
       "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
+      },
+    },
+    Object {
+      "files": Array [
         "**/*.{story,stories}.*",
       ],
       "rules": Object {
@@ -188,6 +198,16 @@ Object {
     },
     Object {
       "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
+      },
+    },
+    Object {
+      "files": Array [
         "**/*.{story,stories}.*",
       ],
       "rules": Object {
@@ -333,6 +353,16 @@ Object {
       ],
       "rules": Object {
         "notice/notice": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
       },
     },
     Object {
@@ -527,6 +557,16 @@ Object {
     },
     Object {
       "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
+      },
+    },
+    Object {
+      "files": Array [
         "**/*.{story,stories}.*",
       ],
       "rules": Object {
@@ -717,6 +757,16 @@ Object {
     },
     Object {
       "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
+      },
+    },
+    Object {
+      "files": Array [
         "**/*.{story,stories}.*",
       ],
       "rules": Object {
@@ -873,6 +923,16 @@ Object {
     },
     Object {
       "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
+      },
+    },
+    Object {
+      "files": Array [
         "**/*.{story,stories}.*",
       ],
       "rules": Object {
@@ -1021,6 +1081,16 @@ Object {
       ],
       "rules": Object {
         "notice/notice": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
       },
     },
     Object {
@@ -1185,6 +1255,16 @@ Object {
     },
     Object {
       "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
+      },
+    },
+    Object {
+      "files": Array [
         "**/*.{story,stories}.*",
       ],
       "rules": Object {
@@ -1340,6 +1420,16 @@ Object {
     },
     Object {
       "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
+      },
+    },
+    Object {
+      "files": Array [
         "**/*.{story,stories}.*",
       ],
       "rules": Object {
@@ -1481,6 +1571,16 @@ Object {
       ],
       "rules": Object {
         "notice/notice": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
       },
     },
     Object {
@@ -1667,6 +1767,16 @@ Object {
       ],
       "rules": Object {
         "notice/notice": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
       },
     },
     Object {
@@ -1859,6 +1969,16 @@ Object {
     },
     Object {
       "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
+      },
+    },
+    Object {
+      "files": Array [
         "**/*.{story,stories}.*",
       ],
       "rules": Object {
@@ -2011,6 +2131,16 @@ Object {
     },
     Object {
       "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
+      },
+    },
+    Object {
+      "files": Array [
         "**/*.{story,stories}.*",
       ],
       "rules": Object {
@@ -2155,6 +2285,16 @@ Object {
       ],
       "rules": Object {
         "notice/notice": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
       },
     },
     Object {
@@ -2314,6 +2454,16 @@ Object {
       },
     },
     Object {
+      "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
+      },
+    },
+    Object {
       "extends": Array [
         "airbnb-typescript/base",
         "plugin:@typescript-eslint/eslint-recommended",
@@ -2597,6 +2747,16 @@ Object {
       },
     },
     Object {
+      "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
+      },
+    },
+    Object {
       "extends": Array [
         "airbnb-typescript/base",
         "plugin:@typescript-eslint/eslint-recommended",
@@ -2867,6 +3027,16 @@ Object {
       ],
       "rules": Object {
         "notice/notice": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
       },
     },
     Object {
@@ -3184,6 +3354,16 @@ Object {
       },
     },
     Object {
+      "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
+      },
+    },
+    Object {
       "extends": Array [
         "airbnb-typescript/base",
         "plugin:@typescript-eslint/eslint-recommended",
@@ -3498,6 +3678,16 @@ Object {
       },
     },
     Object {
+      "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
+      },
+    },
+    Object {
       "extends": Array [
         "airbnb-typescript/base",
         "plugin:@typescript-eslint/eslint-recommended",
@@ -3778,6 +3968,16 @@ Object {
       },
     },
     Object {
+      "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
+      },
+    },
+    Object {
       "extends": Array [
         "airbnb-typescript/base",
         "plugin:@typescript-eslint/eslint-recommended",
@@ -4051,6 +4251,16 @@ Object {
       ],
       "rules": Object {
         "notice/notice": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
       },
     },
     Object {
@@ -4338,6 +4548,16 @@ Object {
       },
     },
     Object {
+      "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
+      },
+    },
+    Object {
       "extends": Array [
         "airbnb-typescript/base",
         "plugin:@typescript-eslint/eslint-recommended",
@@ -4617,6 +4837,16 @@ Object {
       },
     },
     Object {
+      "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
+      },
+    },
+    Object {
       "extends": Array [
         "airbnb-typescript/base",
         "plugin:@typescript-eslint/eslint-recommended",
@@ -4883,6 +5113,16 @@ Object {
       ],
       "rules": Object {
         "notice/notice": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
       },
     },
     Object {
@@ -5193,6 +5433,16 @@ Object {
       ],
       "rules": Object {
         "notice/notice": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
       },
     },
     Object {
@@ -5508,6 +5758,16 @@ Object {
       },
     },
     Object {
+      "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
+      },
+    },
+    Object {
       "extends": Array [
         "airbnb-typescript/base",
         "plugin:@typescript-eslint/eslint-recommended",
@@ -5784,6 +6044,16 @@ Object {
       },
     },
     Object {
+      "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
+      },
+    },
+    Object {
       "extends": Array [
         "airbnb-typescript/base",
         "plugin:@typescript-eslint/eslint-recommended",
@@ -6053,6 +6323,16 @@ Object {
       ],
       "rules": Object {
         "notice/notice": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
       },
     },
     Object {
@@ -6325,6 +6605,16 @@ Object {
       ],
       "rules": Object {
         "notice/notice": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": Object {
+        "no-console": "off",
       },
     },
   ],

--- a/src/configs/eslint/config.ts
+++ b/src/configs/eslint/config.ts
@@ -138,6 +138,8 @@ const unitTestFiles = [
   '**/__mocks__/**/*',
 ];
 
+const nodeFiles = ['api/**/*', 'pages/api/**/*', 'src/pages/api/**/*'];
+
 function customizeLanguage(language?: Language) {
   const languageMap = {
     [Language.JAVASCRIPT]: {
@@ -236,7 +238,7 @@ function customizeEnvironments(environments?: Environment[]) {
       },
       overrides: [
         {
-          files: unitTestFiles,
+          files: [...unitTestFiles, ...nodeFiles],
           rules: {
             'compat/compat': 'off',
           },

--- a/src/configs/eslint/config.ts
+++ b/src/configs/eslint/config.ts
@@ -45,6 +45,18 @@ function customizer(
   return undefined;
 }
 
+const UNIT_TEST_FILES = [
+  '**/*.spec.*',
+  '**/jest*',
+  '**/setupTests.*',
+  '**/test-utils.*',
+  '**/*Fixtures.*',
+  '**/__fixtures__/**/*',
+  '**/__mocks__/**/*',
+];
+
+const NODE_FILES = ['api/**/*', 'pages/api/**/*', 'src/pages/api/**/*'];
+
 const sharedRules = {
   'curly': ['error', 'all'],
   'no-use-before-define': 'off',
@@ -125,20 +137,14 @@ const base = {
         'notice/notice': 'off',
       },
     },
+    {
+      files: NODE_FILES,
+      rules: {
+        'no-console': 'off',
+      },
+    },
   ],
 };
-
-const unitTestFiles = [
-  '**/*.spec.*',
-  '**/jest*',
-  '**/setupTests.*',
-  '**/test-utils.*',
-  '**/*Fixtures.*',
-  '**/__fixtures__/**/*',
-  '**/__mocks__/**/*',
-];
-
-const nodeFiles = ['api/**/*', 'pages/api/**/*', 'src/pages/api/**/*'];
 
 function customizeLanguage(language?: Language) {
   const languageMap = {
@@ -238,7 +244,7 @@ function customizeEnvironments(environments?: Environment[]) {
       },
       overrides: [
         {
-          files: [...unitTestFiles, ...nodeFiles],
+          files: [...UNIT_TEST_FILES, ...NODE_FILES],
           rules: {
             'compat/compat': 'off',
           },
@@ -372,7 +378,7 @@ function customizeFramework(frameworks?: Framework[]) {
     [Framework.JEST]: {
       overrides: [
         {
-          files: unitTestFiles,
+          files: UNIT_TEST_FILES,
           extends: ['plugin:jest/recommended'],
           plugins: ['jest'],
           env: { 'jest/globals': true },
@@ -408,7 +414,7 @@ function customizeFramework(frameworks?: Framework[]) {
     [Framework.TESTING_LIBRARY]: {
       overrides: [
         {
-          files: unitTestFiles,
+          files: UNIT_TEST_FILES,
           extends: ['plugin:testing-library/react'],
           plugins: ['testing-library'],
         },


### PR DESCRIPTION
## Purpose

Configuring ESLint for isomorphic frameworks such as Next.js is tricky since different rules need to apply to code that runs in the browsers vs in Node.js. This PR turns off some rules for [API routes](https://nextjs.org/docs/api-routes/introduction) that don't apply in a Node.js context.

## Approach and changes

- Disable the `compat` plugin for API routes. Ideally, we'd keep it enabled and configure it for Node.js, however, I couldn't find a straightforward way to provide a separate `browserslist` config file for it.
- Disable the `no-console` rule for API routes. Logs can be inspected in Vercel or a log drain if one has been set up.

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
