### PR TITLE
Switch to package exports

### DIFF
--- a/.changeset/early-impalas-rhyme.md
+++ b/.changeset/early-impalas-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@sumup/foundry': major
+---
+
+Changed the [package entry points](https://nodejs.org/api/packages.html#package-entry-points) to use the `exports` instead of the `main` field in the `package.json` file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ To publish a pre-release version, check out on the branch for your release chann
 
 ```sh
 git checkout next # or `canary`
-npm run changeset pre enter next # or `canary`
+npx changeset pre enter next # or `canary`
 ```
 
 This will generate a `pre.json` file in the `.changeset` directory.

--- a/package.json
+++ b/package.json
@@ -2,17 +2,21 @@
   "name": "@sumup/foundry",
   "version": "6.0.0-next.0",
   "description": "A toolkit for JavaScript + TypeScript applications by SumUp.",
-  "main": "index.js",
   "repository": "https://github.com/sumup-oss/foundry",
   "author": "Felix Jung <felix.jung@sumup.com>, Connor Bär <connor.baer@sumup.com>",
   "license": "Apache-2.0",
-  "bin": "cli/index.js",
+  "bin": "dist/cli/index.js",
+  "exports": {
+    "eslint": "./dist/eslint.js",
+    "husky": "./dist/husky.js",
+    "lint-staged": "./dist/lint-staged.js",
+    "prettier": "./dist/prettier.js"
+  },
   "scripts": {
-    "build": "npm run cleanup && npm run copy && tsc && chmod +x dist/cli/index.js",
-    "dev": "npm run cleanup && npm run copy && tsc --watch",
+    "build": "npm run cleanup && tsc && chmod +x dist/cli/index.js",
+    "dev": "npm run cleanup && tsc --watch",
     "start": "npm run dev",
     "cleanup": "rimraf ./dist && mkdir dist",
-    "copy": "cp package.json dist/package.json && cp LICENSE dist/LICENSE && cp README.md dist/README.md",
     "prelint": "npm run build",
     "lint": "eslint src --ext .js,.jsx,.json,.ts,.tsx",
     "lint:fix": "npm run lint -- --fix",
@@ -31,9 +35,6 @@
     "node 14.17",
     "node 16"
   ],
-  "foundry": {
-    "publish": true
-  },
   "dependencies": {
     "@babel/core": "^7.21.4",
     "@babel/eslint-parser": "^7.21.3",


### PR DESCRIPTION
## Purpose

When switching to `changesets` for release automation (#752), I forgot that Foundry is released from _inside_ the `/dist` folder. This was done to keep the import paths for configs clean (e.g. `import createConfig from '@sumup/foundry/eslint';`).

The new `exports` field offers a better way to define [package entry points](https://nodejs.org/api/packages.html#package-entry-points).

## Approach and changes

- Replace `main` with `exports` in `package.json` (supported in Node 11+)

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
