### PR TITLE
Enable type information for jest/unbound-method

### DIFF
--- a/.changeset/neat-frogs-develop.md
+++ b/.changeset/neat-frogs-develop.md
@@ -1,0 +1,5 @@
+---
+'@sumup/foundry': patch
+---
+
+Enabled type checking for unit test files to provide required type information to the `jest/unbound-method` rule.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/sumup-oss/foundry",
   "author": "Felix Jung <felix.jung@sumup.com>, Connor Bär <connor.baer@sumup.com>",
   "license": "Apache-2.0",
+  "files": ["./dist", "./CHANGELOG.md", "./CONTRIBUTING.md"],
   "bin": "dist/cli/index.js",
   "exports": {
     "./eslint": "./dist/eslint.js",

--- a/src/configs/eslint/__snapshots__/config.spec.ts.snap
+++ b/src/configs/eslint/__snapshots__/config.spec.ts.snap
@@ -410,6 +410,7 @@ exports[`eslint with options should return a config for {
       },
       "extends": [
         "plugin:jest/recommended",
+        "plugin:@typescript-eslint/recommended",
       ],
       "files": [
         "**/*.spec.*",
@@ -420,6 +421,20 @@ exports[`eslint with options should return a config for {
         "**/__fixtures__/**/*",
         "**/__mocks__/**/*",
       ],
+      "parserOptions": {
+        "ecmaFeatures": {
+          "modules": true,
+        },
+        "ecmaVersion": 6,
+        "extraFileExtensions": [
+          ".json",
+        ],
+        "project": [
+          "./tsconfig.json",
+        ],
+        "sourceType": "module",
+        "tsconfigRootDir": "/project/dir",
+      },
       "plugins": [
         "jest",
       ],
@@ -1625,6 +1640,7 @@ exports[`eslint with options should return a config for {
       },
       "extends": [
         "plugin:jest/recommended",
+        "plugin:@typescript-eslint/recommended",
       ],
       "files": [
         "**/*.spec.*",
@@ -1635,6 +1651,20 @@ exports[`eslint with options should return a config for {
         "**/__fixtures__/**/*",
         "**/__mocks__/**/*",
       ],
+      "parserOptions": {
+        "ecmaFeatures": {
+          "modules": true,
+        },
+        "ecmaVersion": 6,
+        "extraFileExtensions": [
+          ".json",
+        ],
+        "project": [
+          "./tsconfig.json",
+        ],
+        "sourceType": "module",
+        "tsconfigRootDir": "/project/dir",
+      },
       "plugins": [
         "jest",
       ],
@@ -3208,6 +3238,7 @@ exports[`eslint with options should return a config for {
       },
       "extends": [
         "plugin:jest/recommended",
+        "plugin:@typescript-eslint/recommended",
       ],
       "files": [
         "**/*.spec.*",
@@ -3218,6 +3249,20 @@ exports[`eslint with options should return a config for {
         "**/__fixtures__/**/*",
         "**/__mocks__/**/*",
       ],
+      "parserOptions": {
+        "ecmaFeatures": {
+          "modules": true,
+        },
+        "ecmaVersion": 6,
+        "extraFileExtensions": [
+          ".json",
+        ],
+        "project": [
+          "./tsconfig.json",
+        ],
+        "sourceType": "module",
+        "tsconfigRootDir": "/project/dir",
+      },
       "plugins": [
         "jest",
       ],
@@ -5291,6 +5336,7 @@ exports[`eslint with options should return a config for {
       },
       "extends": [
         "plugin:jest/recommended",
+        "plugin:@typescript-eslint/recommended",
       ],
       "files": [
         "**/*.spec.*",
@@ -5301,6 +5347,20 @@ exports[`eslint with options should return a config for {
         "**/__fixtures__/**/*",
         "**/__mocks__/**/*",
       ],
+      "parserOptions": {
+        "ecmaFeatures": {
+          "modules": true,
+        },
+        "ecmaVersion": 6,
+        "extraFileExtensions": [
+          ".json",
+        ],
+        "project": [
+          "./tsconfig.json",
+        ],
+        "sourceType": "module",
+        "tsconfigRootDir": "/project/dir",
+      },
       "plugins": [
         "jest",
       ],

--- a/src/configs/eslint/config.ts
+++ b/src/configs/eslint/config.ts
@@ -107,6 +107,17 @@ const sharedOverrides = [
   },
 ];
 
+const typeScriptParserOptions = {
+  tsconfigRootDir: process.cwd(),
+  project: ['./tsconfig.json'],
+  extraFileExtensions: ['.json'],
+  sourceType: 'module',
+  ecmaVersion: 6,
+  ecmaFeatures: {
+    modules: true,
+  },
+};
+
 const base = {
   root: true,
   extends: ['eslint:recommended', 'plugin:prettier/recommended', 'airbnb-base'],
@@ -163,16 +174,7 @@ function customizeLanguage(language?: Language) {
           ],
           plugins: ['@typescript-eslint'],
           parser: '@typescript-eslint/parser',
-          parserOptions: {
-            tsconfigRootDir: process.cwd(),
-            project: ['./tsconfig.json'],
-            extraFileExtensions: ['.json'],
-            sourceType: 'module',
-            ecmaVersion: 6,
-            ecmaFeatures: {
-              modules: true,
-            },
-          },
+          parserOptions: typeScriptParserOptions,
           rules: {
             ...sharedRules,
             '@typescript-eslint/explicit-function-return-type': 'off',
@@ -379,9 +381,15 @@ function customizeFramework(frameworks?: Framework[]) {
       overrides: [
         {
           files: UNIT_TEST_FILES,
-          extends: ['plugin:jest/recommended'],
+          extends: [
+            'plugin:jest/recommended',
+            // The `jest/unbound-method` rule requires type information, see
+            // https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/unbound-method.md
+            'plugin:@typescript-eslint/recommended',
+          ],
           plugins: ['jest'],
           env: { 'jest/globals': true },
+          parserOptions: typeScriptParserOptions,
           rules: {
             'jest/unbound-method': 'error',
           },


### PR DESCRIPTION
## Purpose

> Error while loading rule 'jest/unbound-method': You have used a rule which requires parserServices to be generated. You must therefore provide a value for the "parserOptions.project" property for @typescript-eslint/parser.

> In order to use the rules powered by TypeScript type-checking, you must be using @typescript-eslint/parser & adjust your eslint config as outlined [here](https://typescript-eslint.io/linting/typed-linting).

## Approach and changes

- Enabled type checking for unit test files to provide required type information to the `jest/unbound-method` rule.

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
