### PR TITLE
Disable react/no-unknown-property rule for Emotion.js' css prop

### DIFF
--- a/.changeset/rotten-humans-jog.md
+++ b/.changeset/rotten-humans-jog.md
@@ -1,0 +1,5 @@
+---
+'@sumup/foundry': patch
+---
+
+Disabled the `react/no-unknown-property` rule for Emotion.js' `css` prop.

--- a/src/configs/eslint/__snapshots__/config.spec.ts.snap
+++ b/src/configs/eslint/__snapshots__/config.spec.ts.snap
@@ -308,6 +308,14 @@ exports[`eslint with options should return a config for {
     "object-curly-newline": "off",
     "operator-linebreak": "off",
     "quote-props": "off",
+    "react/no-unknown-property": [
+      "error",
+      {
+        "ignore": [
+          "css",
+        ],
+      },
+    ],
   },
   "settings": {
     "import/resolver": {
@@ -1545,6 +1553,14 @@ exports[`eslint with options should return a config for {
     "object-curly-newline": "off",
     "operator-linebreak": "off",
     "quote-props": "off",
+    "react/no-unknown-property": [
+      "error",
+      {
+        "ignore": [
+          "css",
+        ],
+      },
+    ],
   },
   "settings": {
     "import/resolver": {
@@ -3012,6 +3028,14 @@ exports[`eslint with options should return a config for {
     "object-curly-newline": "off",
     "operator-linebreak": "off",
     "quote-props": "off",
+    "react/no-unknown-property": [
+      "error",
+      {
+        "ignore": [
+          "css",
+        ],
+      },
+    ],
   },
   "settings": {
     "import/resolver": {
@@ -5117,6 +5141,14 @@ exports[`eslint with options should return a config for {
     "object-curly-newline": "off",
     "operator-linebreak": "off",
     "quote-props": "off",
+    "react/no-unknown-property": [
+      "error",
+      {
+        "ignore": [
+          "css",
+        ],
+      },
+    ],
   },
   "settings": {
     "import/resolver": {

--- a/src/configs/eslint/config.ts
+++ b/src/configs/eslint/config.ts
@@ -375,6 +375,7 @@ function customizeFramework(frameworks?: Framework[]) {
         '@emotion/no-vanilla': 'error',
         '@emotion/pkg-renaming': 'error',
         '@emotion/styled-import': 'error',
+        'react/no-unknown-property': ['error', { ignore: ['css'] }],
       },
     },
     [Framework.JEST]: {


### PR DESCRIPTION
Addresses #issue-number.

## Purpose

> The [react/no-unknown-property rule](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md) from [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) will produce an error if the `css` prop is passed to a DOM element. This violation of the rule can be safely ignored because `@emotion/react` intercepts the `css` prop before it is applied to the DOM element.

From the [Emotion.js docs](https://emotion.sh/docs/eslint-plugin-react)

## Approach and changes

- Disable the `react/no-unknown-property` rule for Emotion.js' `css` prop

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
