### PR TITLE
Add eslint-plugin-security for Node environments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint-plugin-security": "^1.7.1",
         "eslint-plugin-testing-library": "^5.11.0",
         "husky": "^4.0.0",
         "inquirer": "^8.2.4",
@@ -4787,6 +4788,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/eslint-plugin-security": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-1.7.1.tgz",
+      "integrity": "sha512-sMStceig8AFglhhT2LqlU5r+/fn9OwsA72O5bBuQVTssPCdQAOQzL+oMn/ZcpeUY6KcNfLJArgcrsSULNjYYdQ==",
+      "dependencies": {
+        "safe-regex": "^2.1.1"
+      }
+    },
     "node_modules/eslint-plugin-testing-library": {
       "version": "5.11.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.11.0.tgz",
@@ -9478,6 +9487,14 @@
       "resolved": "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha1-9tyj587sIFkNB62nhWNqkM3KF/k= sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
@@ -9743,6 +9760,14 @@
       "resolved": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0= sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "devOptional": true
+    },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
+      }
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-security": "^1.7.1",
     "eslint-plugin-testing-library": "^5.11.0",
     "husky": "^4.0.0",
     "inquirer": "^8.2.4",

--- a/src/configs/eslint/__snapshots__/config.spec.ts.snap
+++ b/src/configs/eslint/__snapshots__/config.spec.ts.snap
@@ -1271,6 +1271,7 @@ exports[`eslint with options should return a config for {
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
+    "plugin:security/recommended",
   ],
   "overrides": [
     {
@@ -1443,6 +1444,7 @@ exports[`eslint with options should return a config for {
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
+    "plugin:security/recommended",
   ],
   "overrides": [
     {
@@ -1613,6 +1615,7 @@ exports[`eslint with options should return a config for {
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
+    "plugin:security/recommended",
   ],
   "overrides": [
     {
@@ -1789,6 +1792,7 @@ exports[`eslint with options should return a config for {
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
+    "plugin:security/recommended",
     "next",
   ],
   "overrides": [
@@ -1995,6 +1999,7 @@ exports[`eslint with options should return a config for {
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
+    "plugin:security/recommended",
   ],
   "overrides": [
     {
@@ -2161,6 +2166,7 @@ exports[`eslint with options should return a config for {
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
+    "plugin:security/recommended",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",
@@ -2329,6 +2335,7 @@ exports[`eslint with options should return a config for {
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
+    "plugin:security/recommended",
   ],
   "overrides": [
     {
@@ -4676,6 +4683,7 @@ exports[`eslint with options should return a config for {
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
+    "plugin:security/recommended",
   ],
   "overrides": [
     {
@@ -4979,6 +4987,7 @@ exports[`eslint with options should return a config for {
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
+    "plugin:security/recommended",
   ],
   "overrides": [
     {
@@ -5280,6 +5289,7 @@ exports[`eslint with options should return a config for {
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
+    "plugin:security/recommended",
   ],
   "overrides": [
     {
@@ -5587,6 +5597,7 @@ exports[`eslint with options should return a config for {
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
+    "plugin:security/recommended",
     "next",
   ],
   "overrides": [
@@ -5924,6 +5935,7 @@ exports[`eslint with options should return a config for {
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
+    "plugin:security/recommended",
   ],
   "overrides": [
     {
@@ -6221,6 +6233,7 @@ exports[`eslint with options should return a config for {
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
+    "plugin:security/recommended",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",
@@ -6520,6 +6533,7 @@ exports[`eslint with options should return a config for {
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
+    "plugin:security/recommended",
   ],
   "overrides": [
     {

--- a/src/configs/eslint/config.ts
+++ b/src/configs/eslint/config.ts
@@ -255,7 +255,7 @@ function customizeEnvironments(environments?: Environment[]) {
       ],
     },
     [Environment.NODE]: {
-      extends: ['plugin:node/recommended'],
+      extends: ['plugin:node/recommended', 'plugin:security/recommended'],
       env: { node: true },
       rules: {
         // We don't know if the user's source code is using EJS or CJS.


### PR DESCRIPTION
## Purpose

Add [eslint plugin security](https://github.com/eslint-community/eslint-plugin-security) for node environment.

## Approach and changes

Added to eslint config the recommend config of the plugin when environment is node.

## Definition of done

- [ ] Development completed
- [ ] Reviewers assigned
- [x] Unit and integration tests
