### PR TITLE
Add Storybook's ESLint plugin

### DIFF
--- a/.changeset/empty-eagles-rule.md
+++ b/.changeset/empty-eagles-rule.md
@@ -1,0 +1,5 @@
+---
+'@sumup/foundry': major
+---
+
+Added [`eslint-plugin-storybook`](https://github.com/storybookjs/eslint-plugin-storybook)` for projects that use [Storybook](https://storybook.js.org/). This plugin helps conform to Storybook's best practices.

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-security": "^1.7.1",
+        "eslint-plugin-storybook": "^0.6.15",
         "eslint-plugin-testing-library": "^6.2.0",
         "husky": "^4.3.8",
         "inquirer": "^8.2.6",
@@ -72,7 +73,7 @@
         "typescript": "^5.3.2"
       },
       "engines": {
-        "node": "^14.17 || >=16"
+        "node": "^18.12 || >=20"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2130,6 +2131,14 @@
       "devOptional": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@storybook/csf": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.0.1.tgz",
+      "integrity": "sha512-USTLkZze5gkel8MYCujSRBVIrUQ3YPBrLOx7GNk/0wttvVtlzWXAq9eLbQ4p/NicGxP+3T7KPEMVV//g+yubpw==",
+      "dependencies": {
+        "lodash": "^4.17.15"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -5122,6 +5131,23 @@
       "integrity": "sha512-sMStceig8AFglhhT2LqlU5r+/fn9OwsA72O5bBuQVTssPCdQAOQzL+oMn/ZcpeUY6KcNfLJArgcrsSULNjYYdQ==",
       "dependencies": {
         "safe-regex": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-storybook": {
+      "version": "0.6.15",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-0.6.15.tgz",
+      "integrity": "sha512-lAGqVAJGob47Griu29KXYowI4G7KwMoJDOkEip8ujikuDLxU+oWJ1l0WL6F2oDO4QiyUFXvtDkEkISMOPzo+7w==",
+      "dependencies": {
+        "@storybook/csf": "^0.0.1",
+        "@typescript-eslint/utils": "^5.45.0",
+        "requireindex": "^1.1.0",
+        "ts-dedent": "^2.2.0"
+      },
+      "engines": {
+        "node": "12.x || 14.x || >= 16"
+      },
+      "peerDependencies": {
+        "eslint": ">=6"
       }
     },
     "node_modules/eslint-plugin-testing-library": {
@@ -10268,6 +10294,14 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
+    "node_modules/requireindex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
+      "engines": {
+        "node": ">=0.10.5"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -11315,6 +11349,14 @@
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/ts-jest": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-security": "^1.7.1",
+    "eslint-plugin-storybook": "^0.6.15",
     "eslint-plugin-testing-library": "^6.2.0",
     "husky": "^4.3.8",
     "inquirer": "^8.2.6",

--- a/src/configs/eslint/__snapshots__/config.spec.ts.snap
+++ b/src/configs/eslint/__snapshots__/config.spec.ts.snap
@@ -1083,6 +1083,167 @@ exports[`eslint with options should return a config for {
 exports[`eslint with options should return a config for {
   language: 'JavaScript',
   environments: [ 'Browser', [length]: 1 ],
+  frameworks: [ 'Storybook', [length]: 1 ]
+} 1`] = `
+{
+  "env": {
+    "browser": true,
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:prettier/recommended",
+    "airbnb-base",
+    "plugin:compat/recommended",
+    "plugin:storybook/recommended",
+  ],
+  "overrides": [
+    {
+      "extends": [
+        "plugin:json/recommended",
+      ],
+      "files": [
+        "**/*.json",
+      ],
+      "rules": {
+        "notice/notice": "off",
+      },
+    },
+    {
+      "files": [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": {
+        "no-console": "off",
+      },
+    },
+    {
+      "files": [
+        "**/*.{story,stories}.*",
+      ],
+      "rules": {
+        "import/no-anonymous-default-export": "off",
+        "import/no-extraneous-dependencies": "off",
+        "no-alert": "off",
+      },
+    },
+    {
+      "files": [
+        "**/*spec.*",
+        "**/jest*",
+        "**/setupTests.*",
+        "**/test-utils.*",
+      ],
+      "rules": {
+        "import/no-extraneous-dependencies": "off",
+        "react/display-name": "off",
+        "react/prop-types": "off",
+      },
+    },
+    {
+      "files": [
+        "**/*.spec.*",
+        "**/jest*",
+        "**/setupTests.*",
+        "**/test-utils.*",
+        "**/*Fixtures.*",
+        "**/__fixtures__/**/*",
+        "**/__mocks__/**/*",
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": {
+        "compat/compat": "off",
+      },
+    },
+  ],
+  "parser": "@babel/eslint-parser",
+  "parserOptions": {
+    "allowImportExportEverywhere": true,
+    "ecmaFeatures": {
+      "impliedStrict": true,
+      "modules": true,
+    },
+    "ecmaVersion": 6,
+    "sourceType": "module",
+  },
+  "plugins": [
+    "prettier",
+  ],
+  "root": true,
+  "rules": {
+    "comma-dangle": "off",
+    "curly": [
+      "error",
+      "all",
+    ],
+    "function-paren-newline": "off",
+    "implicit-arrow-linebreak": "off",
+    "import/extensions": "off",
+    "import/no-cycle": [
+      "error",
+      {
+        "maxDepth": 7,
+      },
+    ],
+    "import/order": [
+      "error",
+      {
+        "newlines-between": "always",
+      },
+    ],
+    "import/prefer-default-export": "off",
+    "indent": "off",
+    "max-len": [
+      "error",
+      {
+        "code": 80,
+        "ignoreComments": true,
+        "ignorePattern": "^(?:import\\s|export\\s|\\s*it(?:\\.(?:skip|only))?\\()",
+        "ignoreRegExpLiterals": true,
+        "ignoreStrings": true,
+        "ignoreTemplateLiterals": true,
+        "ignoreUrls": true,
+        "tabWidth": 2,
+      },
+    ],
+    "no-confusing-arrow": "off",
+    "no-underscore-dangle": "error",
+    "no-use-before-define": "off",
+    "no-void": [
+      "error",
+      {
+        "allowAsStatement": true,
+      },
+    ],
+    "object-curly-newline": "off",
+    "operator-linebreak": "off",
+    "quote-props": "off",
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "extensions": [
+          ".js",
+          ".jsx",
+          ".ts",
+          ".tsx",
+        ],
+      },
+    },
+    "lintAllEsApis": true,
+    "polyfills": [
+      "document.body",
+    ],
+  },
+}
+`;
+
+exports[`eslint with options should return a config for {
+  language: 'JavaScript',
+  environments: [ 'Browser', [length]: 1 ],
   frameworks: [ 'Testing Library', [length]: 1 ]
 } 1`] = `
 {
@@ -2324,6 +2485,164 @@ exports[`eslint with options should return a config for {
 exports[`eslint with options should return a config for {
   language: 'JavaScript',
   environments: [ 'Node', [length]: 1 ],
+  frameworks: [ 'Storybook', [length]: 1 ]
+} 1`] = `
+{
+  "env": {
+    "node": true,
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:prettier/recommended",
+    "airbnb-base",
+    "plugin:node/recommended",
+    "plugin:security/recommended",
+    "plugin:storybook/recommended",
+  ],
+  "overrides": [
+    {
+      "extends": [
+        "plugin:json/recommended",
+      ],
+      "files": [
+        "**/*.json",
+      ],
+      "rules": {
+        "notice/notice": "off",
+      },
+    },
+    {
+      "files": [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": {
+        "no-console": "off",
+      },
+    },
+    {
+      "files": [
+        "**/*.{story,stories}.*",
+      ],
+      "rules": {
+        "import/no-anonymous-default-export": "off",
+        "import/no-extraneous-dependencies": "off",
+        "no-alert": "off",
+      },
+    },
+    {
+      "files": [
+        "**/*spec.*",
+        "**/jest*",
+        "**/setupTests.*",
+        "**/test-utils.*",
+      ],
+      "rules": {
+        "import/no-extraneous-dependencies": "off",
+        "react/display-name": "off",
+        "react/prop-types": "off",
+      },
+    },
+    {
+      "files": [
+        "**/*.spec.*",
+        "**/jest*",
+        "**/setupTests.*",
+        "**/test-utils.*",
+      ],
+      "rules": {
+        "node/no-extraneous-require": "off",
+        "node/no-missing-require": "off",
+        "node/no-unpublished-import": "off",
+        "node/no-unpublished-require": "off",
+      },
+    },
+  ],
+  "parser": "@babel/eslint-parser",
+  "parserOptions": {
+    "allowImportExportEverywhere": true,
+    "ecmaFeatures": {
+      "impliedStrict": true,
+      "modules": true,
+    },
+    "ecmaVersion": 6,
+    "sourceType": "module",
+  },
+  "plugins": [
+    "prettier",
+  ],
+  "root": true,
+  "rules": {
+    "comma-dangle": "off",
+    "curly": [
+      "error",
+      "all",
+    ],
+    "function-paren-newline": "off",
+    "implicit-arrow-linebreak": "off",
+    "import/extensions": "off",
+    "import/no-cycle": [
+      "error",
+      {
+        "maxDepth": 7,
+      },
+    ],
+    "import/order": [
+      "error",
+      {
+        "newlines-between": "always",
+      },
+    ],
+    "import/prefer-default-export": "off",
+    "indent": "off",
+    "max-len": [
+      "error",
+      {
+        "code": 80,
+        "ignoreComments": true,
+        "ignorePattern": "^(?:import\\s|export\\s|\\s*it(?:\\.(?:skip|only))?\\()",
+        "ignoreRegExpLiterals": true,
+        "ignoreStrings": true,
+        "ignoreTemplateLiterals": true,
+        "ignoreUrls": true,
+        "tabWidth": 2,
+      },
+    ],
+    "no-confusing-arrow": "off",
+    "no-underscore-dangle": "error",
+    "no-use-before-define": "off",
+    "no-void": [
+      "error",
+      {
+        "allowAsStatement": true,
+      },
+    ],
+    "node/no-extraneous-import": "off",
+    "node/no-missing-import": "off",
+    "node/no-unsupported-features/es-syntax": "off",
+    "object-curly-newline": "off",
+    "operator-linebreak": "off",
+    "quote-props": "off",
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "extensions": [
+          ".js",
+          ".jsx",
+          ".ts",
+          ".tsx",
+        ],
+      },
+    },
+  },
+}
+`;
+
+exports[`eslint with options should return a config for {
+  language: 'JavaScript',
+  environments: [ 'Node', [length]: 1 ],
   frameworks: [ 'Testing Library', [length]: 1 ]
 } 1`] = `
 {
@@ -4364,6 +4683,298 @@ exports[`eslint with options should return a config for {
 exports[`eslint with options should return a config for {
   language: 'TypeScript',
   environments: [ 'Browser', [length]: 1 ],
+  frameworks: [ 'Storybook', [length]: 1 ]
+} 1`] = `
+{
+  "env": {
+    "browser": true,
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:prettier/recommended",
+    "airbnb-base",
+    "plugin:compat/recommended",
+    "plugin:storybook/recommended",
+  ],
+  "overrides": [
+    {
+      "extends": [
+        "plugin:json/recommended",
+      ],
+      "files": [
+        "**/*.json",
+      ],
+      "rules": {
+        "notice/notice": "off",
+      },
+    },
+    {
+      "files": [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": {
+        "no-console": "off",
+      },
+    },
+    {
+      "extends": [
+        "airbnb-typescript/base",
+        "plugin:@typescript-eslint/eslint-recommended",
+        "plugin:@typescript-eslint/recommended",
+        "plugin:@typescript-eslint/recommended-requiring-type-checking",
+      ],
+      "files": [
+        "**/*.{ts,tsx}",
+      ],
+      "parser": "@typescript-eslint/parser",
+      "parserOptions": {
+        "ecmaFeatures": {
+          "modules": true,
+        },
+        "ecmaVersion": 6,
+        "extraFileExtensions": [
+          ".json",
+        ],
+        "project": [
+          "./tsconfig.json",
+        ],
+        "sourceType": "module",
+        "tsconfigRootDir": "/project/dir",
+      },
+      "plugins": [
+        "@typescript-eslint",
+      ],
+      "rules": {
+        "@typescript-eslint/explicit-function-return-type": "off",
+        "@typescript-eslint/indent": "off",
+        "@typescript-eslint/no-misused-promises": [
+          "error",
+          {
+            "checksVoidReturn": false,
+          },
+        ],
+        "@typescript-eslint/no-unused-vars": "error",
+        "@typescript-eslint/no-use-before-define": [
+          "error",
+          {
+            "functions": false,
+          },
+        ],
+        "comma-dangle": "off",
+        "curly": [
+          "error",
+          "all",
+        ],
+        "function-paren-newline": "off",
+        "implicit-arrow-linebreak": "off",
+        "import/extensions": "off",
+        "import/no-cycle": [
+          "error",
+          {
+            "maxDepth": 7,
+          },
+        ],
+        "import/order": [
+          "error",
+          {
+            "newlines-between": "always",
+          },
+        ],
+        "import/prefer-default-export": "off",
+        "indent": "off",
+        "max-len": [
+          "error",
+          {
+            "code": 80,
+            "ignoreComments": true,
+            "ignorePattern": "^(?:import\\s|export\\s|\\s*it(?:\\.(?:skip|only))?\\()",
+            "ignoreRegExpLiterals": true,
+            "ignoreStrings": true,
+            "ignoreTemplateLiterals": true,
+            "ignoreUrls": true,
+            "tabWidth": 2,
+          },
+        ],
+        "no-confusing-arrow": "off",
+        "no-underscore-dangle": "error",
+        "no-use-before-define": "off",
+        "no-void": [
+          "error",
+          {
+            "allowAsStatement": true,
+          },
+        ],
+        "object-curly-newline": "off",
+        "operator-linebreak": "off",
+        "quote-props": "off",
+        "react/prop-types": "off",
+      },
+    },
+    {
+      "files": [
+        "**/*.d.ts",
+      ],
+      "rules": {
+        "import/no-extraneous-dependencies": [
+          "error",
+          {
+            "devDependencies": true,
+          },
+        ],
+        "node/no-extraneous-import": "off",
+        "spaced-comment": "off",
+      },
+    },
+    {
+      "files": [
+        "**/*.{story,stories}.{ts,tsx}",
+      ],
+      "rules": {
+        "@typescript-eslint/explicit-module-boundary-types": "off",
+      },
+    },
+    {
+      "files": [
+        "**/*spec.{ts,tsx}",
+        "**/setupTests.{ts,tsx}",
+        "**/test-utils.{ts,tsx}",
+      ],
+      "rules": {
+        "@typescript-eslint/no-empty-function": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/unbound-method": "off",
+      },
+    },
+    {
+      "files": [
+        "**/*.{story,stories}.*",
+      ],
+      "rules": {
+        "import/no-anonymous-default-export": "off",
+        "import/no-extraneous-dependencies": "off",
+        "no-alert": "off",
+      },
+    },
+    {
+      "files": [
+        "**/*spec.*",
+        "**/jest*",
+        "**/setupTests.*",
+        "**/test-utils.*",
+      ],
+      "rules": {
+        "import/no-extraneous-dependencies": "off",
+        "react/display-name": "off",
+        "react/prop-types": "off",
+      },
+    },
+    {
+      "files": [
+        "**/*.spec.*",
+        "**/jest*",
+        "**/setupTests.*",
+        "**/test-utils.*",
+        "**/*Fixtures.*",
+        "**/__fixtures__/**/*",
+        "**/__mocks__/**/*",
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": {
+        "compat/compat": "off",
+      },
+    },
+  ],
+  "parser": "@babel/eslint-parser",
+  "parserOptions": {
+    "allowImportExportEverywhere": true,
+    "ecmaFeatures": {
+      "impliedStrict": true,
+      "modules": true,
+    },
+    "ecmaVersion": 6,
+    "sourceType": "module",
+  },
+  "plugins": [
+    "prettier",
+  ],
+  "root": true,
+  "rules": {
+    "comma-dangle": "off",
+    "curly": [
+      "error",
+      "all",
+    ],
+    "function-paren-newline": "off",
+    "implicit-arrow-linebreak": "off",
+    "import/extensions": "off",
+    "import/no-cycle": [
+      "error",
+      {
+        "maxDepth": 7,
+      },
+    ],
+    "import/order": [
+      "error",
+      {
+        "newlines-between": "always",
+      },
+    ],
+    "import/prefer-default-export": "off",
+    "indent": "off",
+    "max-len": [
+      "error",
+      {
+        "code": 80,
+        "ignoreComments": true,
+        "ignorePattern": "^(?:import\\s|export\\s|\\s*it(?:\\.(?:skip|only))?\\()",
+        "ignoreRegExpLiterals": true,
+        "ignoreStrings": true,
+        "ignoreTemplateLiterals": true,
+        "ignoreUrls": true,
+        "tabWidth": 2,
+      },
+    ],
+    "no-confusing-arrow": "off",
+    "no-underscore-dangle": "error",
+    "no-use-before-define": "off",
+    "no-void": [
+      "error",
+      {
+        "allowAsStatement": true,
+      },
+    ],
+    "object-curly-newline": "off",
+    "operator-linebreak": "off",
+    "quote-props": "off",
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "extensions": [
+          ".js",
+          ".jsx",
+          ".ts",
+          ".tsx",
+        ],
+      },
+    },
+    "lintAllEsApis": true,
+    "polyfills": [
+      "document.body",
+    ],
+  },
+}
+`;
+
+exports[`eslint with options should return a config for {
+  language: 'TypeScript',
+  environments: [ 'Browser', [length]: 1 ],
   frameworks: [ 'Testing Library', [length]: 1 ]
 } 1`] = `
 {
@@ -6514,6 +7125,295 @@ exports[`eslint with options should return a config for {
     },
     "react": {
       "version": "detect",
+    },
+  },
+}
+`;
+
+exports[`eslint with options should return a config for {
+  language: 'TypeScript',
+  environments: [ 'Node', [length]: 1 ],
+  frameworks: [ 'Storybook', [length]: 1 ]
+} 1`] = `
+{
+  "env": {
+    "node": true,
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:prettier/recommended",
+    "airbnb-base",
+    "plugin:node/recommended",
+    "plugin:security/recommended",
+    "plugin:storybook/recommended",
+  ],
+  "overrides": [
+    {
+      "extends": [
+        "plugin:json/recommended",
+      ],
+      "files": [
+        "**/*.json",
+      ],
+      "rules": {
+        "notice/notice": "off",
+      },
+    },
+    {
+      "files": [
+        "api/**/*",
+        "pages/api/**/*",
+        "src/pages/api/**/*",
+      ],
+      "rules": {
+        "no-console": "off",
+      },
+    },
+    {
+      "extends": [
+        "airbnb-typescript/base",
+        "plugin:@typescript-eslint/eslint-recommended",
+        "plugin:@typescript-eslint/recommended",
+        "plugin:@typescript-eslint/recommended-requiring-type-checking",
+      ],
+      "files": [
+        "**/*.{ts,tsx}",
+      ],
+      "parser": "@typescript-eslint/parser",
+      "parserOptions": {
+        "ecmaFeatures": {
+          "modules": true,
+        },
+        "ecmaVersion": 6,
+        "extraFileExtensions": [
+          ".json",
+        ],
+        "project": [
+          "./tsconfig.json",
+        ],
+        "sourceType": "module",
+        "tsconfigRootDir": "/project/dir",
+      },
+      "plugins": [
+        "@typescript-eslint",
+      ],
+      "rules": {
+        "@typescript-eslint/explicit-function-return-type": "off",
+        "@typescript-eslint/indent": "off",
+        "@typescript-eslint/no-misused-promises": [
+          "error",
+          {
+            "checksVoidReturn": false,
+          },
+        ],
+        "@typescript-eslint/no-unused-vars": "error",
+        "@typescript-eslint/no-use-before-define": [
+          "error",
+          {
+            "functions": false,
+          },
+        ],
+        "comma-dangle": "off",
+        "curly": [
+          "error",
+          "all",
+        ],
+        "function-paren-newline": "off",
+        "implicit-arrow-linebreak": "off",
+        "import/extensions": "off",
+        "import/no-cycle": [
+          "error",
+          {
+            "maxDepth": 7,
+          },
+        ],
+        "import/order": [
+          "error",
+          {
+            "newlines-between": "always",
+          },
+        ],
+        "import/prefer-default-export": "off",
+        "indent": "off",
+        "max-len": [
+          "error",
+          {
+            "code": 80,
+            "ignoreComments": true,
+            "ignorePattern": "^(?:import\\s|export\\s|\\s*it(?:\\.(?:skip|only))?\\()",
+            "ignoreRegExpLiterals": true,
+            "ignoreStrings": true,
+            "ignoreTemplateLiterals": true,
+            "ignoreUrls": true,
+            "tabWidth": 2,
+          },
+        ],
+        "no-confusing-arrow": "off",
+        "no-underscore-dangle": "error",
+        "no-use-before-define": "off",
+        "no-void": [
+          "error",
+          {
+            "allowAsStatement": true,
+          },
+        ],
+        "object-curly-newline": "off",
+        "operator-linebreak": "off",
+        "quote-props": "off",
+        "react/prop-types": "off",
+      },
+    },
+    {
+      "files": [
+        "**/*.d.ts",
+      ],
+      "rules": {
+        "import/no-extraneous-dependencies": [
+          "error",
+          {
+            "devDependencies": true,
+          },
+        ],
+        "node/no-extraneous-import": "off",
+        "spaced-comment": "off",
+      },
+    },
+    {
+      "files": [
+        "**/*.{story,stories}.{ts,tsx}",
+      ],
+      "rules": {
+        "@typescript-eslint/explicit-module-boundary-types": "off",
+      },
+    },
+    {
+      "files": [
+        "**/*spec.{ts,tsx}",
+        "**/setupTests.{ts,tsx}",
+        "**/test-utils.{ts,tsx}",
+      ],
+      "rules": {
+        "@typescript-eslint/no-empty-function": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/unbound-method": "off",
+      },
+    },
+    {
+      "files": [
+        "**/*.{story,stories}.*",
+      ],
+      "rules": {
+        "import/no-anonymous-default-export": "off",
+        "import/no-extraneous-dependencies": "off",
+        "no-alert": "off",
+      },
+    },
+    {
+      "files": [
+        "**/*spec.*",
+        "**/jest*",
+        "**/setupTests.*",
+        "**/test-utils.*",
+      ],
+      "rules": {
+        "import/no-extraneous-dependencies": "off",
+        "react/display-name": "off",
+        "react/prop-types": "off",
+      },
+    },
+    {
+      "files": [
+        "**/*.spec.*",
+        "**/jest*",
+        "**/setupTests.*",
+        "**/test-utils.*",
+      ],
+      "rules": {
+        "node/no-extraneous-require": "off",
+        "node/no-missing-require": "off",
+        "node/no-unpublished-import": "off",
+        "node/no-unpublished-require": "off",
+      },
+    },
+  ],
+  "parser": "@babel/eslint-parser",
+  "parserOptions": {
+    "allowImportExportEverywhere": true,
+    "ecmaFeatures": {
+      "impliedStrict": true,
+      "modules": true,
+    },
+    "ecmaVersion": 6,
+    "sourceType": "module",
+  },
+  "plugins": [
+    "prettier",
+  ],
+  "root": true,
+  "rules": {
+    "comma-dangle": "off",
+    "curly": [
+      "error",
+      "all",
+    ],
+    "function-paren-newline": "off",
+    "implicit-arrow-linebreak": "off",
+    "import/extensions": "off",
+    "import/no-cycle": [
+      "error",
+      {
+        "maxDepth": 7,
+      },
+    ],
+    "import/order": [
+      "error",
+      {
+        "newlines-between": "always",
+      },
+    ],
+    "import/prefer-default-export": "off",
+    "indent": "off",
+    "max-len": [
+      "error",
+      {
+        "code": 80,
+        "ignoreComments": true,
+        "ignorePattern": "^(?:import\\s|export\\s|\\s*it(?:\\.(?:skip|only))?\\()",
+        "ignoreRegExpLiterals": true,
+        "ignoreStrings": true,
+        "ignoreTemplateLiterals": true,
+        "ignoreUrls": true,
+        "tabWidth": 2,
+      },
+    ],
+    "no-confusing-arrow": "off",
+    "no-underscore-dangle": "error",
+    "no-use-before-define": "off",
+    "no-void": [
+      "error",
+      {
+        "allowAsStatement": true,
+      },
+    ],
+    "node/no-extraneous-import": "off",
+    "node/no-missing-import": "off",
+    "node/no-unsupported-features/es-syntax": "off",
+    "object-curly-newline": "off",
+    "operator-linebreak": "off",
+    "quote-props": "off",
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "extensions": [
+          ".js",
+          ".jsx",
+          ".ts",
+          ".tsx",
+        ],
+      },
     },
   },
 }

--- a/src/configs/eslint/config.ts
+++ b/src/configs/eslint/config.ts
@@ -416,6 +416,9 @@ function customizeFramework(frameworks?: Framework[]) {
         },
       ],
     },
+    [Framework.STORYBOOK]: {
+      extends: ['plugin:storybook/recommended'],
+    },
   };
   return (config: ESLintConfig): ESLintConfig => {
     if (!frameworks || isEmpty(frameworks)) {

--- a/src/lib/options.spec.ts
+++ b/src/lib/options.spec.ts
@@ -162,6 +162,7 @@ describe('options', () => {
       ['@testing-library/react', Framework.TESTING_LIBRARY],
       ['cypress', Framework.CYPRESS],
       ['playwright', Framework.PLAYWRIGHT],
+      ['storybook', Framework.STORYBOOK],
     ])(
       'should, when `%s` is installed, include the `%s` preset',
       (library, preset) => {

--- a/src/lib/options.ts
+++ b/src/lib/options.ts
@@ -126,6 +126,10 @@ export function detectFrameworks(packageJson: PackageJson): Framework[] {
     frameworks.push(Framework.PLAYWRIGHT);
   }
 
+  if (hasDependency(packageJson, 'storybook')) {
+    frameworks.push(Framework.STORYBOOK);
+  }
+
   return frameworks;
 }
 

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -48,6 +48,7 @@ export enum Framework {
   TESTING_LIBRARY = 'Testing Library',
   CYPRESS = 'Cypress',
   PLAYWRIGHT = 'Playwright',
+  STORYBOOK = 'Storybook',
 }
 
 export interface Options {


### PR DESCRIPTION
## Purpose

Storybook [released](https://storybook.js.org/blog/how-to-use-storybook-with-eslint/) an official ESLint plugin 2 years ago.

## Approach and changes

- Enable Storybook's ESLint plugin with the recommended rules if `storybook` is installed

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
