### PR TITLE
Disable security/detect-object-injection rule

### DIFF
--- a/src/configs/eslint/__snapshots__/config.spec.ts.snap
+++ b/src/configs/eslint/__snapshots__/config.spec.ts.snap
@@ -2908,6 +2908,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "object-curly-newline": "off",
     "operator-linebreak": "off",
     "quote-props": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -3124,6 +3125,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
         ],
       },
     ],
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -3346,6 +3348,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "object-curly-newline": "off",
     "operator-linebreak": "off",
     "quote-props": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -3549,6 +3552,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "object-curly-newline": "off",
     "operator-linebreak": "off",
     "quote-props": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -3761,6 +3765,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "object-curly-newline": "off",
     "operator-linebreak": "off",
     "quote-props": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -3964,6 +3969,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "object-curly-newline": "off",
     "operator-linebreak": "off",
     "quote-props": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -4183,6 +4189,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "object-curly-newline": "off",
     "operator-linebreak": "off",
     "quote-props": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -4410,6 +4417,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "quote-props": "off",
     "react/display-name": "off",
     "react/react-in-jsx-scope": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -4589,6 +4597,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
       },
     ],
     "react/react-in-jsx-scope": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -4774,6 +4783,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "quote-props": "off",
     "react/display-name": "off",
     "react/react-in-jsx-scope": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -4940,6 +4950,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "quote-props": "off",
     "react/display-name": "off",
     "react/react-in-jsx-scope": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -5115,6 +5126,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "quote-props": "off",
     "react/display-name": "off",
     "react/react-in-jsx-scope": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -5281,6 +5293,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "quote-props": "off",
     "react/display-name": "off",
     "react/react-in-jsx-scope": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -5463,6 +5476,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "quote-props": "off",
     "react/display-name": "off",
     "react/react-in-jsx-scope": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -10355,6 +10369,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "object-curly-newline": "off",
     "operator-linebreak": "off",
     "quote-props": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -10702,6 +10717,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
         ],
       },
     ],
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -11055,6 +11071,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "object-curly-newline": "off",
     "operator-linebreak": "off",
     "quote-props": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -11389,6 +11406,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "object-curly-newline": "off",
     "operator-linebreak": "off",
     "quote-props": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -11732,6 +11750,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "object-curly-newline": "off",
     "operator-linebreak": "off",
     "quote-props": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -12066,6 +12085,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "object-curly-newline": "off",
     "operator-linebreak": "off",
     "quote-props": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -12416,6 +12436,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "object-curly-newline": "off",
     "operator-linebreak": "off",
     "quote-props": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -12774,6 +12795,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "quote-props": "off",
     "react/display-name": "off",
     "react/react-in-jsx-scope": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -13084,6 +13106,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
       },
     ],
     "react/react-in-jsx-scope": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -13400,6 +13423,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "quote-props": "off",
     "react/display-name": "off",
     "react/react-in-jsx-scope": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -13697,6 +13721,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "quote-props": "off",
     "react/display-name": "off",
     "react/react-in-jsx-scope": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -14003,6 +14028,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "quote-props": "off",
     "react/display-name": "off",
     "react/react-in-jsx-scope": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -14300,6 +14326,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "quote-props": "off",
     "react/display-name": "off",
     "react/react-in-jsx-scope": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {
@@ -14613,6 +14640,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "quote-props": "off",
     "react/display-name": "off",
     "react/react-in-jsx-scope": "off",
+    "security/detect-object-injection": "off",
   },
   "settings": {
     "import/resolver": {

--- a/src/configs/eslint/config.ts
+++ b/src/configs/eslint/config.ts
@@ -265,6 +265,8 @@ function customizeEnvironments(environments?: Environment[]) {
         'node/no-missing-import': 'off',
         // This rule is already covered by similar ESLint rules.
         'node/no-extraneous-import': 'off',
+        // This rule produces too many false positives.
+        'security/detect-object-injection': 'off',
       },
       overrides: [
         {


### PR DESCRIPTION
## Purpose

This rule produces too many false positives.

## Approach and changes

- Disable [security/detect-object-injection](https://github.com/eslint-community/eslint-plugin-security/blob/main/docs/the-dangers-of-square-bracket-notation.md) rule

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
