### PR TITLE
Add more info to debug command

### DIFF
--- a/.changeset/nervous-dolphins-fix.md
+++ b/.changeset/nervous-dolphins-fix.md
@@ -1,0 +1,5 @@
+---
+"@sumup/foundry": minor
+---
+
+Added a new `debug` command to inspect the detected configuration options.

--- a/.changeset/silly-seals-arrive.md
+++ b/.changeset/silly-seals-arrive.md
@@ -1,0 +1,5 @@
+---
+"@sumup/foundry": minor
+---
+
+Removed the obsolete `publish` option which hasn't been used since v6.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Alternatively, you can pass your answers to the `init` command directly as flags
 
 ```sh
   -o, --openSource  Whether the project is open-source                 [boolean]
-      --publish     Whether to publish to NPM                          [boolean]
   -c, --configDir   The directory to write configs to    [string] [default: "."]
       --overwrite   Whether to overwrite existing config files
                                                       [boolean] [default: false]

--- a/src/cli/debug.ts
+++ b/src/cli/debug.ts
@@ -13,15 +13,20 @@
  * limitations under the License.
  */
 
-import { readPackageJson } from '../lib/files';
-import {
-  warnAboutMissingPlugins,
-  warnAboutUnsupportedPlugins,
-} from '../lib/options';
+import { isArray, isEmpty, mapValues } from 'lodash/fp';
+
+import { getOptions } from '../lib/options';
+import * as logger from '../lib/logger';
 
 export function debug(): void {
-  const packageJson = readPackageJson();
+  const options = getOptions();
 
-  warnAboutUnsupportedPlugins(packageJson);
-  warnAboutMissingPlugins(packageJson);
+  const stringifiedOptions = mapValues(
+    (value) => (isArray(value) && !isEmpty(value) ? value.join(', ') : value),
+    options,
+  );
+
+  logger.empty();
+  logger.info('Detected configuration:');
+  logger.table(stringifiedOptions);
 }

--- a/src/cli/defaults.ts
+++ b/src/cli/defaults.ts
@@ -18,6 +18,5 @@ import { InitOptions } from '../types/shared';
 export const DEFAULT_OPTIONS: InitOptions = {
   configDir: '.',
   openSource: false,
-  publish: false,
   overwrite: false,
 };

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -33,10 +33,6 @@ void yargs
         desc: 'Whether the project is open-source',
         type: 'boolean',
       },
-      publish: {
-        desc: 'Whether to publish to NPM',
-        type: 'boolean',
-      },
       configDir: {
         alias: 'c',
         desc: 'The directory to write configs to',

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -44,7 +44,6 @@ import { DEFAULT_OPTIONS } from './defaults';
 export interface InitParams {
   configDir: string;
   openSource?: boolean;
-  publish?: boolean;
   overwrite?: boolean;
   $0?: string;
   _?: string[];

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -58,3 +58,7 @@ export const debug = (arg: LogMessage): void => {
 export const empty = (): void => {
   console.log('');
 };
+
+export const table = (obj: Record<string, unknown>): void => {
+  console.table(obj);
+};

--- a/src/lib/options.ts
+++ b/src/lib/options.ts
@@ -107,7 +107,6 @@ export function getOptions(): Required<Options> {
     frameworks: pick(config.frameworks, detectFrameworks),
     plugins: pick(config.plugins, detectPlugins),
     openSource: pick(config.openSource, detectOpenSource),
-    publish: Boolean(config.publish),
   };
 }
 

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -63,7 +63,6 @@ export interface Options {
   frameworks?: Framework[];
   plugins?: Plugin[];
   openSource?: boolean;
-  publish?: boolean;
 }
 
 export interface InitOptions extends Options {


### PR DESCRIPTION
## Purpose

Foundry does a lot of magic to detect the appropriate configuration for a project. When it fails, it can be difficult to debug why. The `debug` command is intended to enable developers to inspect the detected options.

## Approach and changes

- Log detected configuration
- Remove the obsolete `publish` option

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
