### PR TITLE
Fix e2e test plugin scope to better support monorepos

### DIFF
--- a/.changeset/green-wasps-repeat.md
+++ b/.changeset/green-wasps-repeat.md
@@ -1,0 +1,5 @@
+---
+"@sumup/foundry": minor
+---
+
+Expanded the scope of the Cypress and Playwright plugins to account for end-to-end test in subdirectories.

--- a/src/configs/eslint/__snapshots__/config.spec.ts.snap
+++ b/src/configs/eslint/__snapshots__/config.spec.ts.snap
@@ -291,8 +291,8 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
       ],
       "files": [
         "**/*spec.*",
-        "e2e/**/*",
-        "tests/**/*",
+        "**/e2e/**/*",
+        "**/tests/**/*",
       ],
       "plugins": [
         "cypress",
@@ -1151,8 +1151,8 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
       ],
       "files": [
         "**/*spec.*",
-        "e2e/**/*",
-        "tests/**/*",
+        "**/e2e/**/*",
+        "**/tests/**/*",
       ],
     },
   ],
@@ -1968,8 +1968,8 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
       ],
       "files": [
         "**/*spec.*",
-        "e2e/**/*",
-        "tests/**/*",
+        "**/e2e/**/*",
+        "**/tests/**/*",
       ],
       "plugins": [
         "cypress",
@@ -2688,8 +2688,8 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
       ],
       "files": [
         "**/*spec.*",
-        "e2e/**/*",
-        "tests/**/*",
+        "**/e2e/**/*",
+        "**/tests/**/*",
       ],
     },
   ],
@@ -3427,8 +3427,8 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
       ],
       "files": [
         "**/*spec.*",
-        "e2e/**/*",
-        "tests/**/*",
+        "**/e2e/**/*",
+        "**/tests/**/*",
       ],
       "plugins": [
         "cypress",
@@ -4287,8 +4287,8 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
       ],
       "files": [
         "**/*spec.*",
-        "e2e/**/*",
-        "tests/**/*",
+        "**/e2e/**/*",
+        "**/tests/**/*",
       ],
     },
   ],
@@ -5102,8 +5102,8 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
       ],
       "files": [
         "**/*spec.*",
-        "e2e/**/*",
-        "tests/**/*",
+        "**/e2e/**/*",
+        "**/tests/**/*",
       ],
       "plugins": [
         "cypress",
@@ -5814,8 +5814,8 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
       ],
       "files": [
         "**/*spec.*",
-        "e2e/**/*",
-        "tests/**/*",
+        "**/e2e/**/*",
+        "**/tests/**/*",
       ],
     },
   ],
@@ -6813,8 +6813,8 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
       ],
       "files": [
         "**/*spec.*",
-        "e2e/**/*",
-        "tests/**/*",
+        "**/e2e/**/*",
+        "**/tests/**/*",
       ],
       "plugins": [
         "cypress",
@@ -8197,8 +8197,8 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
       ],
       "files": [
         "**/*spec.*",
-        "e2e/**/*",
-        "tests/**/*",
+        "**/e2e/**/*",
+        "**/tests/**/*",
       ],
     },
   ],
@@ -9538,8 +9538,8 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
       ],
       "files": [
         "**/*spec.*",
-        "e2e/**/*",
-        "tests/**/*",
+        "**/e2e/**/*",
+        "**/tests/**/*",
       ],
       "plugins": [
         "cypress",
@@ -10782,8 +10782,8 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
       ],
       "files": [
         "**/*spec.*",
-        "e2e/**/*",
-        "tests/**/*",
+        "**/e2e/**/*",
+        "**/tests/**/*",
       ],
     },
   ],
@@ -12045,8 +12045,8 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
       ],
       "files": [
         "**/*spec.*",
-        "e2e/**/*",
-        "tests/**/*",
+        "**/e2e/**/*",
+        "**/tests/**/*",
       ],
       "plugins": [
         "cypress",
@@ -13429,8 +13429,8 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
       ],
       "files": [
         "**/*spec.*",
-        "e2e/**/*",
-        "tests/**/*",
+        "**/e2e/**/*",
+        "**/tests/**/*",
       ],
     },
   ],
@@ -14768,8 +14768,8 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
       ],
       "files": [
         "**/*spec.*",
-        "e2e/**/*",
-        "tests/**/*",
+        "**/e2e/**/*",
+        "**/tests/**/*",
       ],
       "plugins": [
         "cypress",
@@ -16004,8 +16004,8 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
       ],
       "files": [
         "**/*spec.*",
-        "e2e/**/*",
-        "tests/**/*",
+        "**/e2e/**/*",
+        "**/tests/**/*",
       ],
     },
   ],

--- a/src/configs/eslint/config.ts
+++ b/src/configs/eslint/config.ts
@@ -443,7 +443,7 @@ function customizePlugin(plugins?: Plugin[]) {
     [Plugin.CYPRESS]: {
       overrides: [
         {
-          files: ['**/*spec.*', 'e2e/**/*', 'tests/**/*'],
+          files: ['**/*spec.*', '**/e2e/**/*', '**/tests/**/*'],
           extends: ['plugin:cypress/recommended'],
           plugins: ['cypress'],
           env: { 'cypress/globals': true },
@@ -453,7 +453,7 @@ function customizePlugin(plugins?: Plugin[]) {
     [Plugin.PLAYWRIGHT]: {
       overrides: [
         {
-          files: ['**/*spec.*', 'e2e/**/*', 'tests/**/*'],
+          files: ['**/*spec.*', '**/e2e/**/*', '**/tests/**/*'],
           extends: ['plugin:playwright/playwright-test'],
         },
       ],


### PR DESCRIPTION
## Purpose

End-to-end tests might be nested in a subfolder inside monorepos.

## Approach and changes

- Changed the file glob to account for nested e2e test folders

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
