### PR TITLE
Fix Stylelint initialization

### DIFF
--- a/.changeset/red-chefs-vanish.md
+++ b/.changeset/red-chefs-vanish.md
@@ -1,0 +1,5 @@
+---
+"@sumup/foundry": patch
+---
+
+Fixed initializing the Stylelint config files.

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -251,7 +251,7 @@ function getToolsForPresets(selectedPresets: Preset[]): ToolOptions[] {
     flatten,
     uniq,
     map((tool: Tool) => tools[tool]),
-  )(selectedPresets) as ToolOptions[];
+  )(selectedPresets);
 }
 
 function getFilesForTools(

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -19,10 +19,12 @@ import * as eslint from './eslint';
 import * as husky from './husky';
 import * as lintStaged from './lint-staged';
 import * as prettier from './prettier';
+import * as stylelint from './stylelint';
 
-export const tools: { [key in Tool]?: ToolOptions } = {
+export const tools: Record<Tool, ToolOptions> = {
   [Tool.ESLINT]: eslint,
   [Tool.HUSKY]: husky,
   [Tool.LINT_STAGED]: lintStaged,
   [Tool.PRETTIER]: prettier,
+  [Tool.STYLELINT]: stylelint,
 };

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -46,4 +46,4 @@ function formatName(name: string, description: string): string {
   return [`${chalk.bold(name)}:`, description].join(' ');
 }
 
-export const presets = { lint };
+export const presets: Record<Preset, PresetConfig> = { lint };


### PR DESCRIPTION
## Purpose

In #916, I forgot to add Stylelint to the list of tools, thus breaking the `foundry init` command.

## Approach and changes

- Add Stylelint to the list of tools

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
