### PR TITLE
Upgrade stylelint-config-recess-order to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sumup/foundry",
-  "version": "7.0.0-next.2",
+  "version": "7.0.0-next.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sumup/foundry",
-      "version": "7.0.0-next.2",
+      "version": "7.0.0-next.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.23.7",
@@ -41,7 +41,7 @@
         "read-pkg-up": "^7.0.1",
         "semver": "^7.5.4",
         "stylelint": "^16.2.0",
-        "stylelint-config-recess-order": "^4.4.0",
+        "stylelint-config-recess-order": "^5.0.0",
         "stylelint-config-standard": "^36.0.0",
         "stylelint-no-unsupported-browser-features": "^8.0.0",
         "yargs": "^17.7.2"
@@ -7497,11 +7497,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
-    "node_modules/lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q=="
-    },
     "node_modules/lodash.startcase": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
@@ -10142,14 +10137,14 @@
       }
     },
     "node_modules/stylelint-config-recess-order": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recess-order/-/stylelint-config-recess-order-4.4.0.tgz",
-      "integrity": "sha512-Q99kvZyIM/aoPEV4dRDkzD3fZLzH0LXi+pawCf1r700uUeF/PHQ5PZXjwFUuGrWhOzd1N+cuVm+OUGsY2fRN5A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recess-order/-/stylelint-config-recess-order-5.0.0.tgz",
+      "integrity": "sha512-D+/Got844O96No2mj/H2NhLjj555iKAy/Mea+JCerfKB9TBKQW3/IudSVkTCxE4QiRDLldfH15x6FH1D1Anjhw==",
       "dependencies": {
-        "stylelint-order": "6.x"
+        "stylelint-order": "^6.0.4"
       },
       "peerDependencies": {
-        "stylelint": ">=15"
+        "stylelint": ">=16"
       }
     },
     "node_modules/stylelint-config-recommended": {
@@ -10178,12 +10173,11 @@
       }
     },
     "node_modules/stylelint-no-unsupported-browser-features": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-no-unsupported-browser-features/-/stylelint-no-unsupported-browser-features-8.0.0.tgz",
-      "integrity": "sha512-XrXaizW90HdswC+2V1XJXsvNrMUt/bk8OJ7ZDn3nKZzE5NAd4rmAIo/igKuGzHA2a6vx5FplhD5VOqSLYDPnYg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-no-unsupported-browser-features/-/stylelint-no-unsupported-browser-features-8.0.1.tgz",
+      "integrity": "sha512-tc8Xn5DaqJhxTmbA4H8gZbYdAz027NfuSZv5+cVieQb7BtBrF/1/iKYdpcGwXPl3GtqkQrisiXuGqKkKnzWcLw==",
       "dependencies": {
         "doiuse": "^6.0.2",
-        "lodash.pick": "^4.4.0",
         "postcss": "^8.4.32"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "read-pkg-up": "^7.0.1",
     "semver": "^7.5.4",
     "stylelint": "^16.2.0",
-    "stylelint-config-recess-order": "^4.4.0",
+    "stylelint-config-recess-order": "^5.0.0",
     "stylelint-config-standard": "^36.0.0",
     "stylelint-no-unsupported-browser-features": "^8.0.0",
     "yargs": "^17.7.2"


### PR DESCRIPTION
Follow-up to #926. Relates to https://github.com/stormwarning/stylelint-config-recess-order/pull/352.

## Approach and changes

- Upgrade `stylelint-config-recess-order` to v5 to support Stylelint 16

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
