### PR TITLE
Reduce the scope of the integration test globs

### DIFF
--- a/.changeset/gentle-adults-protect.md
+++ b/.changeset/gentle-adults-protect.md
@@ -1,0 +1,5 @@
+---
+'@sumup/foundry': patch
+---
+
+Reduced the scope of the integration test file globs to prevent false positive lint issues in unit test files. Integration tests must be located in the `e2e/` or `tests/` folders in the repo or [workspace](https://docs.npmjs.com/cli/v7/using-npm/workspaces) root directories.

--- a/src/configs/eslint/__snapshots__/config.spec.ts.snap
+++ b/src/configs/eslint/__snapshots__/config.spec.ts.snap
@@ -290,9 +290,8 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
         "plugin:cypress/recommended",
       ],
       "files": [
-        "**/*spec.*",
-        "**/e2e/**/*",
-        "**/tests/**/*",
+        "e2e/**/*",
+        "tests/**/*",
       ],
       "plugins": [
         "cypress",
@@ -1150,9 +1149,8 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
         "plugin:playwright/playwright-test",
       ],
       "files": [
-        "**/*spec.*",
-        "**/e2e/**/*",
-        "**/tests/**/*",
+        "e2e/**/*",
+        "tests/**/*",
       ],
     },
   ],
@@ -1967,9 +1965,8 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
         "plugin:cypress/recommended",
       ],
       "files": [
-        "**/*spec.*",
-        "**/e2e/**/*",
-        "**/tests/**/*",
+        "e2e/**/*",
+        "tests/**/*",
       ],
       "plugins": [
         "cypress",
@@ -2687,9 +2684,8 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
         "plugin:playwright/playwright-test",
       ],
       "files": [
-        "**/*spec.*",
-        "**/e2e/**/*",
-        "**/tests/**/*",
+        "e2e/**/*",
+        "tests/**/*",
       ],
     },
   ],
@@ -3426,9 +3422,8 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
         "plugin:cypress/recommended",
       ],
       "files": [
-        "**/*spec.*",
-        "**/e2e/**/*",
-        "**/tests/**/*",
+        "e2e/**/*",
+        "tests/**/*",
       ],
       "plugins": [
         "cypress",
@@ -4286,9 +4281,8 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
         "plugin:playwright/playwright-test",
       ],
       "files": [
-        "**/*spec.*",
-        "**/e2e/**/*",
-        "**/tests/**/*",
+        "e2e/**/*",
+        "tests/**/*",
       ],
     },
   ],
@@ -5101,9 +5095,8 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
         "plugin:cypress/recommended",
       ],
       "files": [
-        "**/*spec.*",
-        "**/e2e/**/*",
-        "**/tests/**/*",
+        "e2e/**/*",
+        "tests/**/*",
       ],
       "plugins": [
         "cypress",
@@ -5813,9 +5806,8 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
         "plugin:playwright/playwright-test",
       ],
       "files": [
-        "**/*spec.*",
-        "**/e2e/**/*",
-        "**/tests/**/*",
+        "e2e/**/*",
+        "tests/**/*",
       ],
     },
   ],
@@ -6812,9 +6804,8 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
         "plugin:cypress/recommended",
       ],
       "files": [
-        "**/*spec.*",
-        "**/e2e/**/*",
-        "**/tests/**/*",
+        "e2e/**/*",
+        "tests/**/*",
       ],
       "plugins": [
         "cypress",
@@ -8196,9 +8187,8 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
         "plugin:playwright/playwright-test",
       ],
       "files": [
-        "**/*spec.*",
-        "**/e2e/**/*",
-        "**/tests/**/*",
+        "e2e/**/*",
+        "tests/**/*",
       ],
     },
   ],
@@ -9537,9 +9527,8 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
         "plugin:cypress/recommended",
       ],
       "files": [
-        "**/*spec.*",
-        "**/e2e/**/*",
-        "**/tests/**/*",
+        "e2e/**/*",
+        "tests/**/*",
       ],
       "plugins": [
         "cypress",
@@ -10781,9 +10770,8 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
         "plugin:playwright/playwright-test",
       ],
       "files": [
-        "**/*spec.*",
-        "**/e2e/**/*",
-        "**/tests/**/*",
+        "e2e/**/*",
+        "tests/**/*",
       ],
     },
   ],
@@ -12044,9 +12032,8 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
         "plugin:cypress/recommended",
       ],
       "files": [
-        "**/*spec.*",
-        "**/e2e/**/*",
-        "**/tests/**/*",
+        "e2e/**/*",
+        "tests/**/*",
       ],
       "plugins": [
         "cypress",
@@ -13428,9 +13415,8 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
         "plugin:playwright/playwright-test",
       ],
       "files": [
-        "**/*spec.*",
-        "**/e2e/**/*",
-        "**/tests/**/*",
+        "e2e/**/*",
+        "tests/**/*",
       ],
     },
   ],
@@ -14767,9 +14753,8 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
         "plugin:cypress/recommended",
       ],
       "files": [
-        "**/*spec.*",
-        "**/e2e/**/*",
-        "**/tests/**/*",
+        "e2e/**/*",
+        "tests/**/*",
       ],
       "plugins": [
         "cypress",
@@ -16003,9 +15988,8 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
         "plugin:playwright/playwright-test",
       ],
       "files": [
-        "**/*spec.*",
-        "**/e2e/**/*",
-        "**/tests/**/*",
+        "e2e/**/*",
+        "tests/**/*",
       ],
     },
   ],

--- a/src/configs/eslint/config.spec.ts
+++ b/src/configs/eslint/config.spec.ts
@@ -19,7 +19,11 @@ import { Language, Environment, Framework, Plugin } from '../../types/shared';
 import { getAllChoiceCombinations } from '../../lib/choices';
 import { getOptions as getOptionsMock } from '../../lib/options';
 
-import { customizeConfig, createConfig } from './config';
+import {
+  customizeConfig,
+  createConfig,
+  getFileGlobsForWorkspaces,
+} from './config';
 
 vi.mock('process', () => ({
   cwd: (): string => '/project/dir',
@@ -101,6 +105,29 @@ describe('eslint', () => {
       };
       const actual = customizeConfig(base, custom);
       expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('getFileGlobsForWorkspaces', () => {
+    const files = ['e2e/**/*', '*.spec.*'];
+
+    it('should return the file globs unchanged when the workspaces are null', () => {
+      const workspaces = null;
+      const actual = getFileGlobsForWorkspaces(workspaces, files);
+      expect(actual).toEqual(files);
+    });
+
+    it('should return the file globs raw and prefixed with each workspace', () => {
+      const workspaces = ['packages/*', 'docs'];
+      const actual = getFileGlobsForWorkspaces(workspaces, files);
+      expect(actual).toEqual([
+        'e2e/**/*',
+        '*.spec.*',
+        'packages/*/e2e/**/*',
+        'packages/*/*.spec.*',
+        'docs/e2e/**/*',
+        'docs/*.spec.*',
+      ]);
     });
   });
 

--- a/src/lib/options.ts
+++ b/src/lib/options.ts
@@ -107,6 +107,7 @@ export function getOptions(): Required<Options> {
     frameworks: pick(config.frameworks, detectFrameworks),
     plugins: pick(config.plugins, detectPlugins),
     openSource: pick(config.openSource, detectOpenSource),
+    workspaces: packageJson.workspaces || null,
   };
 }
 

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -57,12 +57,15 @@ export enum Plugin {
   TESTING_LIBRARY = 'Testing Library',
 }
 
+export type Workspaces = string[] | null;
+
 export interface Options {
   language?: Language;
   environments?: Environment[];
   frameworks?: Framework[];
   plugins?: Plugin[];
   openSource?: boolean;
+  workspaces?: Workspaces;
 }
 
 export interface InitOptions extends Options {
@@ -87,4 +90,6 @@ export interface ToolOptions {
   scripts?: (options: InitOptions) => Script[];
 }
 
-export type PackageJson = NormalizedPackageJson;
+export type PackageJson = NormalizedPackageJson & {
+  workspaces?: string[];
+};


### PR DESCRIPTION
## Purpose

Foundry v7 broadened the glob pattern for integration test files to support monorepos better. This had the unfortunate side-effect that integration test lint rules were wrongly applied to unit test files.

## Approach and changes

- Reduce the scope of the integration test glob patterns to the `e2e` and `tests` folders at the repo or workspace root

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
