### PR TITLE
Add support for Circuit UI's Stylelint plugin

### DIFF
--- a/.changeset/tough-geckos-turn.md
+++ b/.changeset/tough-geckos-turn.md
@@ -1,0 +1,5 @@
+---
+'@sumup/foundry': minor
+---
+
+Added support for [Circuit UI's Stylelint plugin](https://circuit.sumup.com/?path=/docs/packages-stylelint-plugin-circuit-ui--docs).

--- a/src/configs/eslint/config.spec.ts
+++ b/src/configs/eslint/config.spec.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { describe, expect, it, vi, Mock } from 'vitest';
+import { describe, expect, it, vi, type Mock } from 'vitest';
 
 import { Language, Environment, Framework, Plugin } from '../../types/shared';
 import { getAllChoiceCombinations } from '../../lib/choices';

--- a/src/configs/stylelint/__snapshots__/config.spec.ts.snap
+++ b/src/configs/stylelint/__snapshots__/config.spec.ts.snap
@@ -1,0 +1,54 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`stylelint > with options > should return a config for { plugins: ['Circuit UI'] } 1`] = `
+{
+  "extends": [
+    "stylelint-config-standard",
+    "stylelint-config-recess-order",
+  ],
+  "plugins": [
+    "stylelint-no-unsupported-browser-features",
+    "@sumup/circuit-ui",
+  ],
+  "reportDescriptionlessDisables": true,
+  "reportInvalidScopeDisables": true,
+  "reportNeedlessDisables": true,
+  "rules": {
+    "@sumup/circuit-ui/component-lifecycle-imports": "error",
+    "@sumup/circuit-ui/no-deprecated-components": "warn",
+    "@sumup/circuit-ui/no-deprecated-props": "warn",
+    "@sumup/circuit-ui/no-invalid-custom-properties": "error",
+    "@sumup/circuit-ui/no-renamed-props": "error",
+    "declaration-block-no-redundant-longhand-properties": null,
+    "media-feature-range-notation": [
+      "prefix",
+    ],
+    "no-descending-specificity": null,
+    "plugin/no-unsupported-browser-features": [
+      true,
+      {
+        "ignorePartialSupport": true,
+        "severity": "warning",
+      },
+    ],
+    "selector-class-pattern": null,
+    "selector-not-notation": [
+      "simple",
+    ],
+    "selector-pseudo-class-no-unknown": [
+      true,
+      {
+        "ignorePseudoClasses": [
+          "global",
+        ],
+      },
+    ],
+    "value-keyword-case": [
+      "lower",
+      {
+        "camelCaseSvgKeywords": true,
+      },
+    ],
+  },
+}
+`;

--- a/src/configs/stylelint/config.spec.ts
+++ b/src/configs/stylelint/config.spec.ts
@@ -13,9 +13,18 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, type Mock } from 'vitest';
+
+import { Plugin } from '../../types/shared';
+import { getOptions as getOptionsMock } from '../../lib/options';
 
 import { customizeConfig, createConfig } from './config';
+
+vi.mock('../../lib/options', () => ({
+  getOptions: vi.fn(() => ({})),
+}));
+
+const getOptions = getOptionsMock as Mock;
 
 describe('stylelint', () => {
   describe('customizeConfig', () => {
@@ -104,6 +113,14 @@ describe('stylelint', () => {
           ]),
         }),
       );
+    });
+  });
+
+  describe('with options', () => {
+    it("should return a config for { plugins: ['Circuit UI'] }", () => {
+      getOptions.mockReturnValue({ plugins: [Plugin.CIRCUIT_UI] });
+      const actual = createConfig();
+      expect(actual).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
## Purpose

Circuit UI offers both an ESLint and a Stylelint plugin to ensure the correct usage of its design tokens.

## Approach and changes

- Automatically configure [Circuit UI's Stylelint plugin](https://circuit.sumup.com/?path=/docs/packages-stylelint-plugin-circuit-ui--docs) when it is installed

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
