### PR TITLE
Discourage external contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing
 
-## Contributor License Agreement (CLA)
+## Don't work at SumUp?
 
-To start contributing to SumUp Open Source projects, [please accept our Contributor License Agreement](https://opensource.sumup.com/cla). Should you have any questions or concerns, please get in touch with [opensource@sumup.com](mailto:opensource@sumup.com).
+In an effort to give back to the community from which we learn so much, our documentation and code are public. However, the intended use case for Foundry is internal, so please treat this as a read-only project and inspiration only.
 
 ## Code of Conduct (CoC)
 


### PR DESCRIPTION
## Purpose

Our contributor license agreement (CLA) bot has been unmaintained and broken for a while, leading to confusion for internal contributors. This project is intended for internal use and hasn't received external contributions recently, so we've decided to remove the CLA bot and only allow contributions from SumUp employees.

## Approach and changes

- Discourage external contributions
