### PR TITLE
Upgrade to eslint-plugin-security v3

### DIFF
--- a/.changeset/chatty-squids-happen.md
+++ b/.changeset/chatty-squids-happen.md
@@ -1,0 +1,5 @@
+---
+'@sumup/foundry': major
+---
+
+Upgraded `eslint-plugin-security` to v3. Read the [changelog](https://github.com/eslint-community/eslint-plugin-security/blob/main/CHANGELOG.md).

--- a/.changeset/dirty-crews-suffer.md
+++ b/.changeset/dirty-crews-suffer.md
@@ -2,10 +2,4 @@
 '@sumup/foundry': major
 ---
 
-Update of linter libraries to support the latest versions of Typescript:
-
-- @typescript-eslint/eslint-plugin
-- @typescript-eslint/parser
-- eslint-config-airbnb-typescript
-
-This is a breaking change as the introduction of ESLint v9 requires a minimum Node version of v18.18, whereas previously Foundry only required v18.12+.
+Upgraded `@typescript-eslint/*` to v7. Read the [changelog](https://github.com/typescript-eslint/typescript-eslint/blob/main/CHANGELOG.md).

--- a/.changeset/fair-timers-joke.md
+++ b/.changeset/fair-timers-joke.md
@@ -1,0 +1,5 @@
+---
+'@sumup/foundry': major
+---
+
+Raised the minimum Node version to ^18.18 || ^20.9 || >=22.

--- a/.changeset/unlucky-boxes-clap.md
+++ b/.changeset/unlucky-boxes-clap.md
@@ -1,0 +1,5 @@
+---
+'@sumup/foundry': major
+---
+
+Upgraded `eslint-config-airbnb-typescript` to v18. Read the [release notes](https://github.com/iamturns/eslint-config-airbnb-typescript/releases/tag/v18.0.0).

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20]
+        node: [18, 20, 22]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1642,6 +1642,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -1658,6 +1659,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
       "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -1669,6 +1671,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -1680,6 +1683,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -1696,6 +1700,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -1710,6 +1715,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -1901,6 +1907,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=14"
@@ -2255,9 +2262,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.19.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.0.tgz",
-      "integrity": "sha512-667KNhaD7U29mT5wf+TZUnrzPrlL2GNQ5N0BMjO2oNULhBxX0/FKCkm6JMu0Jh7Z+1LwUlR21ekd7KhIboNFNw==",
+      "version": "18.19.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.33.tgz",
+      "integrity": "sha512-NR9+KrpSajr2qBVp/Yt5TU/rp+b5Mayi3+OlMlcg2cVCfRmcG5PWZ7S4+MG9PZ5gWBoc9Pd0BKSRViuBCRPu0A==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -3970,7 +3977,8 @@
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.643",
@@ -4838,9 +4846,9 @@
       }
     },
     "node_modules/eslint/node_modules/globals": {
-      "version": "13.23.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
-      "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -5292,6 +5300,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
       "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
@@ -5457,14 +5466,14 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -6429,6 +6438,7 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
       "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
+      "dev": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -8040,9 +8050,10 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
+      "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -8578,11 +8589,12 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-scurry": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
-      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.2.tgz",
+      "integrity": "sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==",
+      "dev": true,
       "dependencies": {
-        "lru-cache": "^9.1.1 || ^10.0.0",
+        "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
@@ -8593,9 +8605,10 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
-      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
+      "dev": true,
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -9385,6 +9398,7 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.5.tgz",
       "integrity": "sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==",
+      "dev": true,
       "dependencies": {
         "glob": "^10.3.7"
       },
@@ -9402,20 +9416,22 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/rimraf/node_modules/glob": {
-      "version": "10.3.10",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "version": "10.3.12",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.12.tgz",
+      "integrity": "sha512-TCNv8vJ+xz4QiqTpfOJA7HvYv+tNIRHKfUWw/q+v2jdgN4ebz+KY9tGx5J4rHP0o84mNP+ApH66HRX8us3Khqg==",
+      "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.5",
+        "jackspeak": "^2.3.6",
         "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
+        "minipass": "^7.0.4",
+        "path-scurry": "^1.10.2"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
@@ -9428,9 +9444,10 @@
       }
     },
     "node_modules/rimraf/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -10032,6 +10049,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -10044,7 +10062,8 @@
     "node_modules/string-width-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/string-width/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -10132,6 +10151,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -10382,13 +10402,12 @@
       }
     },
     "node_modules/stylelint/node_modules/flat-cache": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.0.tgz",
-      "integrity": "sha512-EryKbCE/wxpxKniQlyas6PY1I9vwtF3uCBweX+N8KYTCn3Y12RTGtQAJ/bd5pl7kxUAc8v/R3Ake/N17OZiFqA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dependencies": {
         "flatted": "^3.2.9",
-        "keyv": "^4.5.4",
-        "rimraf": "^5.0.5"
+        "keyv": "^4.5.4"
       },
       "engines": {
         "node": ">=16"
@@ -11329,6 +11348,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-react-hooks": "^4.6.2",
-        "eslint-plugin-security": "^1.7.1",
+        "eslint-plugin-security": "^3.0.0",
         "husky": "^4.3.8",
         "inquirer": "^8.2.6",
         "is-ci": "^3.0.1",
@@ -70,7 +70,7 @@
         "vitest": "^1.6.0"
       },
       "engines": {
-        "node": "^18.12 || >=20"
+        "node": "^18.18 || >=20"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4731,11 +4731,14 @@
       }
     },
     "node_modules/eslint-plugin-security": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-1.7.1.tgz",
-      "integrity": "sha512-sMStceig8AFglhhT2LqlU5r+/fn9OwsA72O5bBuQVTssPCdQAOQzL+oMn/ZcpeUY6KcNfLJArgcrsSULNjYYdQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-3.0.0.tgz",
+      "integrity": "sha512-2Ij7PkmXIF2cKwoVkEgemwoXbOnxg5UfdhdcpNxZwJxC/10dbsdhHISrTyJ/n8DUkt3yiN6P1ywEgcMGjIwHIw==",
       "dependencies": {
         "safe-regex": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -35,11 +35,12 @@
     "release": "changeset publish"
   },
   "engines": {
-    "node": "^18.12 || >=20"
+    "node": "^18.18 || ^20.9 || >=22"
   },
   "browserslist": [
-    "node 18.12",
-    "node 20"
+    "node 18.18",
+    "node 20.9",
+    "node 22"
   ],
   "dependencies": {
     "@babel/core": "^7.24.5",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^4.6.2",
-    "eslint-plugin-security": "^1.7.1",
+    "eslint-plugin-security": "^3.0.0",
     "husky": "^4.3.8",
     "inquirer": "^8.2.6",
     "is-ci": "^3.0.1",

--- a/src/configs/eslint/__snapshots__/config.spec.ts.snap
+++ b/src/configs/eslint/__snapshots__/config.spec.ts.snap
@@ -3144,7 +3144,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
   ],
   "overrides": [
     {
@@ -3353,7 +3353,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
   ],
   "overrides": [
     {
@@ -3571,7 +3571,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
   ],
   "overrides": [
     {
@@ -3788,7 +3788,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
   ],
   "overrides": [
     {
@@ -4011,7 +4011,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
     "next",
   ],
   "overrides": [
@@ -4215,7 +4215,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
   ],
   "overrides": [
     {
@@ -4427,7 +4427,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
     "plugin:storybook/recommended",
   ],
   "overrides": [
@@ -4631,7 +4631,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
   ],
   "overrides": [
     {
@@ -4851,7 +4851,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",
@@ -5023,7 +5023,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",
@@ -5204,7 +5204,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",
@@ -5384,7 +5384,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",
@@ -5570,7 +5570,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",
@@ -5737,7 +5737,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",
@@ -5912,7 +5912,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",
@@ -6079,7 +6079,7 @@ exports[`eslint > with options > should return a config for { language: 'JavaScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",
@@ -11492,7 +11492,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
   ],
   "overrides": [
     {
@@ -11832,7 +11832,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
   ],
   "overrides": [
     {
@@ -12181,7 +12181,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
   ],
   "overrides": [
     {
@@ -12529,7 +12529,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
   ],
   "overrides": [
     {
@@ -12883,7 +12883,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
     "next",
   ],
   "overrides": [
@@ -13218,7 +13218,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
   ],
   "overrides": [
     {
@@ -13561,7 +13561,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
     "plugin:storybook/recommended",
   ],
   "overrides": [
@@ -13896,7 +13896,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
   ],
   "overrides": [
     {
@@ -14247,7 +14247,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",
@@ -14550,7 +14550,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",
@@ -14862,7 +14862,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",
@@ -15173,7 +15173,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",
@@ -15490,7 +15490,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",
@@ -15788,7 +15788,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",
@@ -16094,7 +16094,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",
@@ -16392,7 +16392,7 @@ exports[`eslint > with options > should return a config for { language: 'TypeScr
     "plugin:prettier/recommended",
     "airbnb-base",
     "plugin:node/recommended",
-    "plugin:security/recommended",
+    "plugin:security/recommended-legacy",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",

--- a/src/configs/eslint/config.ts
+++ b/src/configs/eslint/config.ts
@@ -278,7 +278,10 @@ function customizeEnvironments(environments: Environment[]) {
       ],
     },
     [Environment.NODE]: {
-      extends: ['plugin:node/recommended', 'plugin:security/recommended'],
+      extends: [
+        'plugin:node/recommended',
+        'plugin:security/recommended-legacy',
+      ],
       env: { node: true },
       rules: {
         // We don't know if the user's source code is using EJS or CJS.


### PR DESCRIPTION
## Purpose

[`eslint-plugin-security` v3](https://github.com/eslint-community/eslint-plugin-security/blob/main/CHANGELOG.md#300-2024-04-10) adds support for ESLint v9 and raises the minimum Node version to ^18.18.0 || ^20.9.0 || >=21.1.0.

I've raised Foundry's minimum Node version to ^18.18 || ^20.9 || >=22 (ie. excluding Node 21, in accordance with our policy of supporting only active LTS versions).

## Approach and changes

- Upgrade to `eslint-plugin-security` v3
- Raise the minimum Node version to ^18.18 || ^20.9 || >=22 and add Node 22 to the CI test matrix
- Dedupe the dependencies

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
