### PR TITLE
Allow empty Stylelint input on precommit

### DIFF
--- a/.changeset/plenty-cows-cross.md
+++ b/.changeset/plenty-cows-cross.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/foundry": patch
+---
+
+Prevented Styleling from throwing an error when all matched input files are ignored during a pre-commit check.

--- a/src/configs/lint-staged/__snapshots__/config.spec.ts.snap
+++ b/src/configs/lint-staged/__snapshots__/config.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`lint-staged > should override the default config 1`] = `
   ],
   "*.(ts|tsx)": [Function],
   "*.css": [
-    "foundry run stylelint --fix",
+    "foundry run stylelint --fix --allow-empty-input",
   ],
   "*.jsx?": [
     "custom command",
@@ -25,7 +25,7 @@ exports[`lint-staged > with options > should return a config for { useBiome: fal
   ],
   "*.(ts|tsx)": [Function],
   "*.css": [
-    "foundry run stylelint --fix",
+    "foundry run stylelint --fix --allow-empty-input",
   ],
 }
 `;
@@ -40,7 +40,7 @@ exports[`lint-staged > with options > should return a config for { useBiome: tru
   ],
   "*.(ts|tsx)": [Function],
   "*.css": [
-    "foundry run stylelint --fix",
+    "foundry run stylelint --fix --allow-empty-input",
   ],
 }
 `;

--- a/src/configs/lint-staged/config.ts
+++ b/src/configs/lint-staged/config.ts
@@ -32,14 +32,14 @@ export function config(overrides: LintStagedConfig = {}): LintStagedConfig {
       ],
       '*.(js|jsx|ts|tsx)': ['foundry run eslint --fix'],
       '*.(ts|tsx)': () => 'tsc -p tsconfig.json --noEmit',
-      '*.css': ['foundry run stylelint --fix'],
+      '*.css': ['foundry run stylelint --fix --allow-empty-input'],
       ...overrides,
     };
   }
   return {
     '*.(js|jsx|json|ts|tsx)': ['foundry run eslint --fix'],
     '*.(ts|tsx)': () => 'tsc -p tsconfig.json --noEmit',
-    '*.css': ['foundry run stylelint --fix'],
+    '*.css': ['foundry run stylelint --fix --allow-empty-input'],
     ...overrides,
   };
 }


### PR DESCRIPTION
## Purpose

When committing changes only to CSS files listed in `.stylelintignore`, Stylelint throws an error.

## Approach and changes

- Allow empty input to Stylelint on precommit

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
