### PR TITLE
Remove unmaintained ESLint plugins

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,17 +13,8 @@
  * limitations under the License.
  */
 
-// eslint-disable-next-line node/no-unpublished-require
 module.exports = require('./dist/eslint')({
   rules: {
     'no-process-exit': 'off',
   },
-  overrides: [
-    {
-      files: ['src/cli/index.ts'],
-      rules: {
-        'node/shebang': 'off',
-      },
-    },
-  ],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-compat": "^4.2.0",
-        "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-notice": "^1.0.0",
         "eslint-plugin-react": "^7.37.3",
@@ -2022,11 +2021,6 @@
         "win32"
       ]
     },
-    "node_modules/@rtsao/scc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
-      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="
-    },
     "node_modules/@samverschueren/stream-to-observable": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
@@ -2095,11 +2089,6 @@
       "dependencies": {
         "ci-info": "^3.1.0"
       }
-    },
-    "node_modules/@types/json5": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
     "node_modules/@types/listr": {
       "version": "0.14.9",
@@ -2991,25 +2980,6 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
       "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.findlastindex": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.5.tgz",
-      "integrity": "sha512-zfETvRFA8o7EiNn++N5f/kaCw221hrpGsDmcpndVupkPzEc1Wuf3VgC0qby1BbHs7f5DVYjgtEU2LLh5bqeGfQ==",
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -4433,50 +4403,6 @@
         "eslint": ">=7.0.0"
       }
     },
-    "node_modules/eslint-import-resolver-node": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
-      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
-      "dependencies": {
-        "debug": "^3.2.7",
-        "is-core-module": "^2.13.0",
-        "resolve": "^1.22.4"
-      }
-    },
-    "node_modules/eslint-import-resolver-node/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-module-utils": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.0.tgz",
-      "integrity": "sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.2.7"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
     "node_modules/eslint-plugin-compat": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-4.2.0.tgz",
@@ -4563,66 +4489,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-import": {
-      "version": "2.31.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
-      "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
-      "license": "MIT",
-      "dependencies": {
-        "@rtsao/scc": "^1.1.0",
-        "array-includes": "^3.1.8",
-        "array.prototype.findlastindex": "^1.2.5",
-        "array.prototype.flat": "^1.3.2",
-        "array.prototype.flatmap": "^1.3.2",
-        "debug": "^3.2.7",
-        "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.9",
-        "eslint-module-utils": "^2.12.0",
-        "hasown": "^2.0.2",
-        "is-core-module": "^2.15.1",
-        "is-glob": "^4.0.3",
-        "minimatch": "^3.1.2",
-        "object.fromentries": "^2.0.8",
-        "object.groupby": "^1.0.3",
-        "object.values": "^1.2.0",
-        "semver": "^6.3.1",
-        "string.prototype.trimend": "^1.0.8",
-        "tsconfig-paths": "^3.15.0"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
-      }
-    },
-    "node_modules/eslint-plugin-import/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-plugin-import/node_modules/doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/eslint-plugin-import/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-plugin-jsx-a11y": {
@@ -8066,6 +7932,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -8333,19 +8200,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.groupby": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
-      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/object.values": {
@@ -10011,6 +9865,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -10582,28 +10437,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
-      }
-    },
-    "node_modules/tsconfig-paths": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
-      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
-      "dependencies": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.2",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
-      }
-    },
-    "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
       }
     },
     "node_modules/tslib": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "eslint-plugin-compat": "^4.2.0",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
-        "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-notice": "^1.0.0",
         "eslint-plugin-react": "^7.37.3",
         "eslint-plugin-react-hooks": "^4.6.2",
@@ -1317,14 +1316,18 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
+      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
+      "license": "MIT",
       "dependencies": {
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
@@ -1342,9 +1345,10 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
-      "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -4561,24 +4565,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/eslint-plugin-es": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
-      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
-      "dependencies": {
-        "eslint-utils": "^2.0.0",
-        "regexpp": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=4.19.1"
-      }
-    },
     "node_modules/eslint-plugin-import": {
       "version": "2.31.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
@@ -4666,33 +4652,6 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
-      }
-    },
-    "node_modules/eslint-plugin-node": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
-      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
-      "dependencies": {
-        "eslint-plugin-es": "^3.0.0",
-        "eslint-utils": "^2.0.0",
-        "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.10.1",
-        "semver": "^6.1.0"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=5.16.0"
-      }
-    },
-    "node_modules/eslint-plugin-node/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-plugin-notice": {
@@ -4818,28 +4777,6 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/eslint-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-      "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
-    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/eslint-visitor-keys": {
@@ -9204,17 +9141,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/regexpp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-compat": "^4.2.0",
-    "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-notice": "^1.0.0",
     "eslint-plugin-react": "^7.37.3",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "eslint-plugin-compat": "^4.2.0",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
-    "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-notice": "^1.0.0",
     "eslint-plugin-react": "^7.37.3",
     "eslint-plugin-react-hooks": "^4.6.2",

--- a/src/configs/eslint/config.ts
+++ b/src/configs/eslint/config.ts
@@ -419,7 +419,7 @@ function customizeLanguage(language: Language) {
           files: ['**/*.d.ts'],
           rules: {
             'spaced-comment': 'off',
-            'node/no-extraneous-import': 'off',
+            // 'node/no-extraneous-import': 'off',
             'import/no-extraneous-dependencies': [
               'error',
               { devDependencies: true },
@@ -479,38 +479,35 @@ function customizeEnvironments(environments: Environment[]) {
       ],
     },
     [Environment.NODE]: {
-      extends: [
-        'plugin:node/recommended',
-        'plugin:security/recommended-legacy',
-      ],
+      extends: ['plugin:security/recommended-legacy'],
       env: { node: true },
       rules: {
         // We don't know if the user's source code is using EJS or CJS.
-        'node/no-unsupported-features/es-syntax': 'off',
+        // 'node/no-unsupported-features/es-syntax': 'off',
         // This rule breaks when used in combination with TypeScript
         // and is already covered by similar ESLint rules.
-        'node/no-missing-import': 'off',
+        // 'node/no-missing-import': 'off',
         // This rule is already covered by similar ESLint rules.
-        'node/no-extraneous-import': 'off',
+        // 'node/no-extraneous-import': 'off',
         // This rule produces too many false positives.
         'security/detect-object-injection': 'off',
       },
-      overrides: [
-        {
-          files: [
-            '**/*.spec.*',
-            '**/jest*',
-            '**/setupTests.*',
-            '**/test-utils.*',
-          ],
-          rules: {
-            'node/no-unpublished-import': 'off',
-            'node/no-unpublished-require': 'off',
-            'node/no-missing-require': 'off',
-            'node/no-extraneous-require': 'off',
-          },
-        },
-      ],
+      // overrides: [
+      //   {
+      //     files: [
+      //       '**/*.spec.*',
+      //       '**/jest*',
+      //       '**/setupTests.*',
+      //       '**/test-utils.*',
+      //     ],
+      //     rules: {
+      //       'node/no-unpublished-import': 'off',
+      //       'node/no-unpublished-require': 'off',
+      //       'node/no-missing-require': 'off',
+      //       'node/no-extraneous-require': 'off',
+      //     },
+      //   },
+      // ],
     },
   };
   return (config: ESLintConfig): ESLintConfig => {

--- a/src/configs/eslint/config.ts
+++ b/src/configs/eslint/config.ts
@@ -35,7 +35,7 @@ import { node } from './rules/node';
 import { style } from './rules/style';
 import { variables } from './rules/variables';
 import { es6 } from './rules/es6';
-import { imports } from './rules/imports';
+// import { imports } from './rules/imports';
 import { strict } from './rules/strict';
 import { typescript } from './rules/typescript';
 
@@ -103,10 +103,10 @@ const sharedRules = {
     },
   ],
   'no-underscore-dangle': 'error',
-  'import/prefer-default-export': 'off',
-  'import/no-cycle': ['error', { maxDepth: 7 }],
-  'import/order': ['error', { 'newlines-between': 'always' }],
-  'import/extensions': 'off',
+  // 'import/prefer-default-export': 'off',
+  // 'import/no-cycle': ['error', { maxDepth: 7 }],
+  // 'import/order': ['error', { 'newlines-between': 'always' }],
+  // 'import/extensions': 'off',
   'no-void': ['error', { allowAsStatement: true }],
 };
 
@@ -114,15 +114,15 @@ const sharedOverrides = [
   {
     files: ['**/*.{story,stories}.*'],
     rules: {
-      'import/no-extraneous-dependencies': 'off',
-      'import/no-anonymous-default-export': 'off',
+      // 'import/no-extraneous-dependencies': 'off',
+      // 'import/no-anonymous-default-export': 'off',
       'no-alert': 'off',
     },
   },
   {
     files: ['**/*spec.*', '**/jest*', '**/setupTests.*', '**/test-utils.*'],
     rules: {
-      'import/no-extraneous-dependencies': 'off',
+      // 'import/no-extraneous-dependencies': 'off',
       'react/display-name': 'off',
       'react/prop-types': 'off',
     },
@@ -144,13 +144,13 @@ const sumup = {
     },
     allowImportExportEverywhere: true,
   },
-  settings: {
-    'import/resolver': {
-      node: {
-        extensions: ['.js', '.jsx', '.ts', '.tsx'],
-      },
-    },
-  },
+  // settings: {
+  //   'import/resolver': {
+  //     node: {
+  //       extensions: ['.js', '.jsx', '.ts', '.tsx'],
+  //     },
+  //   },
+  // },
   rules: sharedRules,
   overrides: [
     {
@@ -169,7 +169,7 @@ const base = flow(
   (config) => customizeConfig(config, style),
   (config) => customizeConfig(config, variables),
   (config) => customizeConfig(config, es6),
-  (config) => customizeConfig(config, imports),
+  // (config) => customizeConfig(config, imports),
   (config) => customizeConfig(config, strict),
   (config) => customizeConfig(config, sumup),
 )({
@@ -420,10 +420,10 @@ function customizeLanguage(language: Language) {
           rules: {
             'spaced-comment': 'off',
             // 'node/no-extraneous-import': 'off',
-            'import/no-extraneous-dependencies': [
-              'error',
-              { devDependencies: true },
-            ],
+            // 'import/no-extraneous-dependencies': [
+            //   'error',
+            //   { devDependencies: true },
+            // ],
           },
         },
         {

--- a/src/configs/eslint/rules/typescript.ts
+++ b/src/configs/eslint/rules/typescript.ts
@@ -16,31 +16,31 @@
 import { bestPractices } from './best-practices';
 import { errors } from './errors';
 import { es6 } from './es6';
-import { imports } from './imports';
+// import { imports } from './imports';
 import { style } from './style';
 import { variables } from './variables';
 
 export const typescript = {
   plugins: ['@typescript-eslint'],
   parser: '@typescript-eslint/parser',
-  settings: {
-    // Apply special parsing for TypeScript files
-    'import/parsers': {
-      '@typescript-eslint/parser': ['.ts', '.tsx', '.d.ts'],
-    },
-    // Append 'ts' extensions to Airbnb 'import/resolver' setting
-    // Original: ['.mjs', '.js', '.json']
-    'import/resolver': {
-      node: {
-        extensions: ['.mjs', '.js', '.json', '.ts', '.d.ts'],
-      },
-    },
-    // Append 'ts' extensions to Airbnb 'import/extensions' setting
-    // Original: ['.js', '.mjs', '.jsx']
-    'import/extensions': ['.js', '.mjs', '.jsx', '.ts', '.tsx', '.d.ts'],
-    // Resolve type definition packages
-    'import/external-module-folders': ['node_modules', 'node_modules/@types'],
-  },
+  // settings: {
+  //   // Apply special parsing for TypeScript files
+  //   'import/parsers': {
+  //     '@typescript-eslint/parser': ['.ts', '.tsx', '.d.ts'],
+  //   },
+  //   // Append 'ts' extensions to Airbnb 'import/resolver' setting
+  //   // Original: ['.mjs', '.js', '.json']
+  //   'import/resolver': {
+  //     node: {
+  //       extensions: ['.mjs', '.js', '.json', '.ts', '.d.ts'],
+  //     },
+  //   },
+  //   // Append 'ts' extensions to Airbnb 'import/extensions' setting
+  //   // Original: ['.js', '.mjs', '.jsx']
+  //   'import/extensions': ['.js', '.mjs', '.jsx', '.ts', '.tsx', '.d.ts'],
+  //   // Resolve type definition packages
+  //   'import/external-module-folders': ['node_modules', 'node_modules/@types'],
+  // },
   rules: {
     // Replace Airbnb 'brace-style' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/brace-style.md
@@ -260,34 +260,34 @@ export const typescript = {
 
     // Append 'ts' and 'tsx' to Airbnb 'import/extensions' rule
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md
-    'import/extensions': [
-      imports.rules['import/extensions'][0],
-      imports.rules['import/extensions'][1],
-      {
-        ...imports.rules['import/extensions'][2],
-        ts: 'never',
-        tsx: 'never',
-      },
-    ],
+    // 'import/extensions': [
+    //   imports.rules['import/extensions'][0],
+    //   imports.rules['import/extensions'][1],
+    //   {
+    //     ...imports.rules['import/extensions'][2],
+    //     ts: 'never',
+    //     tsx: 'never',
+    //   },
+    // ],
 
     // Append 'ts' and 'tsx' extensions to Airbnb 'import/no-extraneous-dependencies' rule
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md
-    'import/no-extraneous-dependencies': [
-      imports.rules['import/no-extraneous-dependencies'][0],
-      {
-        ...imports.rules['import/no-extraneous-dependencies'][1],
-        devDependencies: imports.rules[
-          'import/no-extraneous-dependencies'
-        ][1].devDependencies.reduce((result, devDep) => {
-          const toAppend: string[] = [devDep];
-          const devDepWithTs = devDep.replace(/\bjs(x?)\b/g, 'ts$1');
-          if (devDepWithTs !== devDep) {
-            toAppend.push(devDepWithTs);
-          }
-          return result.concat(toAppend);
-        }, [] as string[]),
-      },
-    ],
+    // 'import/no-extraneous-dependencies': [
+    //   imports.rules['import/no-extraneous-dependencies'][0],
+    //   {
+    //     ...imports.rules['import/no-extraneous-dependencies'][1],
+    //     devDependencies: imports.rules[
+    //       'import/no-extraneous-dependencies'
+    //     ][1].devDependencies.reduce((result, devDep) => {
+    //       const toAppend: string[] = [devDep];
+    //       const devDepWithTs = devDep.replace(/\bjs(x?)\b/g, 'ts$1');
+    //       if (devDepWithTs !== devDep) {
+    //         toAppend.push(devDepWithTs);
+    //       }
+    //       return result.concat(toAppend);
+    //     }, [] as string[]),
+    //   },
+    // ],
   },
   overrides: [
     {
@@ -315,10 +315,10 @@ export const typescript = {
         'valid-typeof': 'off',
         // The following rules are enabled in Airbnb config, but are recommended to be disabled within TypeScript projects
         // See: https://github.com/typescript-eslint/typescript-eslint/blob/13583e65f5973da2a7ae8384493c5e00014db51b/docs/linting/TROUBLESHOOTING.md#eslint-plugin-import
-        'import/named': 'off',
-        'import/no-named-as-default-member': 'off',
+        // 'import/named': 'off',
+        // 'import/no-named-as-default-member': 'off',
         // Disable `import/no-unresolved`, see README.md for details
-        'import/no-unresolved': 'off',
+        // 'import/no-unresolved': 'off',
       },
     },
   ],


### PR DESCRIPTION
Addresses [WBPL-411](https://sumupteam.atlassian.net/browse/WBPL-411).

## Purpose

[`eslint-plugin-node`](https://www.npmjs.com/package/eslint-plugin-node) and [`eslint-plugin-import`](https://www.npmjs.com/package/eslint-plugin-import) are no longer maintained and are incompatible with ESLint v9.

Both plugins have replacements ([`eslint-plugin-n`](https://www.npmjs.com/package/eslint-plugin-n) and `[eslint-plugin-import-x`](https://www.npmjs.com/package/eslint-plugin-import-x), however, I plan to install and configure them after the upgrade to ESLint v9, once I've figured out how to use the new flat config.

## Approach and changes

- Remove `eslint-plugin-node` and `eslint-plugin-import` and disable their associated rules temporarily

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests