### PR TITLE
Enable continuous releases with pkg.pr.new

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Create release PR or publish to npm
-        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next' || github.ref == 'refs/heads/canary') && matrix.node == 18
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next' || github.ref == 'refs/heads/canary') && matrix.node == 22
         uses: changesets/action@v1
         with:
           publish: npm run release

--- a/.github/workflows/cr.yaml
+++ b/.github/workflows/cr.yaml
@@ -1,0 +1,25 @@
+name: Continuous Releases
+
+on: [pull_request]
+
+jobs:
+  cr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish
+        run: npx pkg-pr-new publish


### PR DESCRIPTION
## Purpose

Foundry can't be tested by locally linking the package due to how it resolves its sub-dependencies.

## Approach and changes

- Set up https://github.com/stackblitz-labs/pkg.pr.new to publish prereleases for PRs

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
