### PR TITLE
Update supported plugin version ranges

### DIFF
--- a/.changeset/polite-paths-vanish.md
+++ b/.changeset/polite-paths-vanish.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/foundry': major
+---
+
+Updated the supported ESLint and Stylelint plugin version ranges to drop support for plugins that don't support ESLint's new flat config and declare support for the latest plugin versions.

--- a/src/configs/stylelint/__snapshots__/config.spec.ts.snap
+++ b/src/configs/stylelint/__snapshots__/config.spec.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`stylelint > with options > should return a config for { plugins: ['Circuit UI (OSS scope)'] } 1`] = `
+exports[`stylelint > with options > should return a config for { plugins: ['Circuit UI'] } 1`] = `
 {
   "extends": [
     "stylelint-config-standard",
@@ -16,77 +16,6 @@ exports[`stylelint > with options > should return a config for { plugins: ['Circ
     "at-rule-no-unknown": null,
     "block-no-empty": null,
     "circuit-ui/no-deprecated-custom-properties": true,
-    "circuit-ui/no-invalid-custom-properties": true,
-    "custom-property-no-missing-var-function": null,
-    "declaration-block-no-duplicate-custom-properties": null,
-    "declaration-block-no-duplicate-properties": null,
-    "declaration-block-no-redundant-longhand-properties": null,
-    "declaration-block-no-shorthand-property-overrides": null,
-    "declaration-no-important": null,
-    "font-family-no-duplicate-names": null,
-    "font-family-no-missing-generic-family-keyword": null,
-    "function-linear-gradient-no-nonstandard-direction": null,
-    "function-no-unknown": null,
-    "keyframe-block-no-duplicate-selectors": null,
-    "keyframe-declaration-no-important": null,
-    "media-feature-name-no-unknown": null,
-    "media-feature-range-notation": [
-      "prefix",
-    ],
-    "named-grid-areas-no-invalid": null,
-    "no-descending-specificity": null,
-    "no-duplicate-at-import-rules": null,
-    "no-invalid-position-at-import-rule": null,
-    "no-irregular-whitespace": null,
-    "plugin/no-unsupported-browser-features": [
-      true,
-      {
-        "ignorePartialSupport": true,
-        "severity": "warning",
-      },
-    ],
-    "property-no-unknown": null,
-    "selector-anb-no-unmatchable": null,
-    "selector-class-pattern": null,
-    "selector-not-notation": [
-      "simple",
-    ],
-    "selector-pseudo-class-no-unknown": [
-      true,
-      {
-        "ignorePseudoClasses": [
-          "global",
-        ],
-      },
-    ],
-    "selector-pseudo-element-no-unknown": null,
-    "selector-type-no-unknown": null,
-    "unit-no-unknown": null,
-    "value-keyword-case": [
-      "lower",
-      {
-        "camelCaseSvgKeywords": true,
-      },
-    ],
-  },
-}
-`;
-
-exports[`stylelint > with options > should return a config for { plugins: ['Circuit UI'] } 1`] = `
-{
-  "extends": [
-    "stylelint-config-standard",
-  ],
-  "plugins": [
-    "stylelint-no-unsupported-browser-features",
-    "@sumup/stylelint-plugin-circuit-ui",
-  ],
-  "reportDescriptionlessDisables": true,
-  "reportInvalidScopeDisables": true,
-  "reportNeedlessDisables": true,
-  "rules": {
-    "at-rule-no-unknown": null,
-    "block-no-empty": null,
     "circuit-ui/no-invalid-custom-properties": true,
     "custom-property-no-missing-var-function": null,
     "declaration-block-no-duplicate-custom-properties": null,

--- a/src/configs/stylelint/config.spec.ts
+++ b/src/configs/stylelint/config.spec.ts
@@ -123,11 +123,5 @@ describe('stylelint', () => {
       const actual = defineConfig();
       expect(actual).toMatchSnapshot();
     });
-
-    it("should return a config for { plugins: ['Circuit UI (OSS scope)'] }", () => {
-      getPlugins.mockReturnValue([Plugin.CircuitUIOSS]);
-      const actual = defineConfig();
-      expect(actual).toMatchSnapshot();
-    });
   });
 });

--- a/src/configs/stylelint/config.ts
+++ b/src/configs/stylelint/config.ts
@@ -86,12 +86,6 @@ const base: StylelintConfig = {
 function customizePlugin(plugins: Plugin[]) {
   const pluginMap: { [Key in Plugin]?: StylelintConfig } = {
     [Plugin.CircuitUI]: {
-      plugins: ['@sumup/stylelint-plugin-circuit-ui'],
-      rules: {
-        'circuit-ui/no-invalid-custom-properties': true,
-      },
-    },
-    [Plugin.CircuitUIOSS]: {
       plugins: ['@sumup-oss/stylelint-plugin-circuit-ui'],
       rules: {
         'circuit-ui/no-invalid-custom-properties': true,

--- a/src/lib/options.spec.ts
+++ b/src/lib/options.spec.ts
@@ -197,7 +197,6 @@ describe('options', () => {
   describe('detectPlugins', () => {
     it.each([
       ['eslint-config-next', Plugin.Nextjs],
-      ['@emotion/eslint-plugin', Plugin.Emotion],
       ['eslint-plugin-jest', Plugin.Jest],
       ['eslint-plugin-testing-library', Plugin.TestingLibrary],
       ['eslint-plugin-cypress', Plugin.Cypress],
@@ -220,13 +219,13 @@ describe('options', () => {
       const packageJson = {
         ...basePackageJson,
         dependencies: {
-          '@emotion/eslint-plugin': '^1.0.0',
+          '@sumup-oss/eslint-plugin-circuit-ui': '^6.0.0',
           'eslint-config-next': '^1.0.0',
         },
       };
       const actual = detectPlugins(packageJson);
 
-      expect(actual).toContain(Plugin.Emotion);
+      expect(actual).toContain(Plugin.CircuitUI);
       expect(actual).toContain(Plugin.Nextjs);
     });
   });
@@ -264,14 +263,14 @@ describe('options', () => {
       const packageJson = {
         ...basePackageJson,
         license: 'MIT',
-        dependencies: { 'eslint-config-next': '^9.0.0' },
+        dependencies: { 'eslint-config-next': '^13.0.0' },
       };
 
       warnAboutUnsupportedPlugins(packageJson);
 
       expect(logger.warn).toHaveBeenCalledOnce();
       expect(logger.warn).toHaveBeenCalledWith(
-        '"eslint-config-next" is installed at version "^9.0.0". Foundry has only been tested with versions ">=10.0.0". You may find that it works just fine, or you may not. Pull requests welcome!',
+        '"eslint-config-next" is installed at version "^13.0.0". Foundry has only been tested with versions ">=14.0.0". You may find that it works just fine, or you may not. Pull requests welcome!',
       );
     });
 
@@ -279,14 +278,14 @@ describe('options', () => {
       const packageJson = {
         ...basePackageJson,
         license: 'MIT',
-        dependencies: { 'eslint-plugin-playwright': '^2.0.0' },
+        dependencies: { 'eslint-plugin-playwright': '^3.0.0' },
       };
 
       warnAboutUnsupportedPlugins(packageJson);
 
       expect(logger.warn).toHaveBeenCalledOnce();
       expect(logger.warn).toHaveBeenCalledWith(
-        '"eslint-plugin-playwright" is installed at version "^2.0.0". Foundry has only been tested with versions ">=0.17.0 <2.0.0". You may find that it works just fine, or you may not. Pull requests welcome!',
+        '"eslint-plugin-playwright" is installed at version "^3.0.0". Foundry has only been tested with versions ">=2.0.0 <3.0.0". You may find that it works just fine, or you may not. Pull requests welcome!',
       );
     });
 
@@ -295,8 +294,8 @@ describe('options', () => {
         ...basePackageJson,
         license: 'MIT',
         dependencies: {
-          '@sumup/eslint-plugin-circuit-ui':
-            'https://registry.npmjs.org/@sumup/eslint-plugin-circuit-ui/-/eslint-plugin-circuit-ui-1.0.0.tgz',
+          '@sumup-oss/eslint-plugin-circuit-ui':
+            'https://registry.npmjs.org/@sumup-oss/eslint-plugin-circuit-ui/-/eslint-plugin-circuit-ui-5.0.0.tgz',
         },
       };
 
@@ -304,7 +303,7 @@ describe('options', () => {
 
       expect(logger.warn).toHaveBeenCalledOnce();
       expect(logger.warn).toHaveBeenCalledWith(
-        '"@sumup/eslint-plugin-circuit-ui" is installed at version "1.0.0". Foundry has only been tested with versions ">=3.0.0 <5.0.0". You may find that it works just fine, or you may not. Pull requests welcome!',
+        '"@sumup-oss/eslint-plugin-circuit-ui" is installed at version "5.0.0". Foundry has only been tested with versions ">=7.0.0 <8.0.0". You may find that it works just fine, or you may not. Pull requests welcome!',
       );
     });
 
@@ -331,7 +330,7 @@ describe('options', () => {
         license: 'MIT',
         dependencies: {
           'next': '^1.0.0',
-          '@emotion/react': '^1.0.0',
+          '@playwright/test': '^10.0.0',
         },
       };
 
@@ -342,7 +341,7 @@ describe('options', () => {
         '"next" is installed but not the corresponding ESLint plugin. Please install "eslint-config-next".',
       );
       expect(logger.warn).toHaveBeenCalledWith(
-        '"@emotion/react" is installed but not the corresponding ESLint plugin. Please install "@emotion/eslint-plugin".',
+        '"@playwright/test" is installed but not the corresponding ESLint plugin. Please install "eslint-plugin-playwright".',
       );
     });
   });

--- a/src/lib/options.ts
+++ b/src/lib/options.ts
@@ -42,31 +42,24 @@ const PLUGINS = [
     name: Plugin.CircuitUI,
     frameworkPackages: ['@sumup-oss/circuit-ui', '@sumup-oss/design-tokens'],
     eslintPlugins: {
-      '@sumup-oss/eslint-plugin-circuit-ui': '>=5.0.0 <6.0.0',
+      '@sumup-oss/eslint-plugin-circuit-ui': '>=7.0.0 <8.0.0',
     },
     stylelintPlugins: {
-      '@sumup-oss/stylelint-plugin-circuit-ui': '>=3.0.0 <4.0.0',
+      '@sumup-oss/stylelint-plugin-circuit-ui': '>=3.0.0 <5.0.0',
     },
   },
   {
     name: Plugin.Nextjs,
     frameworkPackages: ['next'],
     eslintPlugins: {
-      'eslint-config-next': '>=10.0.0',
-    },
-  },
-  {
-    name: Plugin.Emotion,
-    frameworkPackages: ['@emotion/react', '@emotion/styled'],
-    eslintPlugins: {
-      '@emotion/eslint-plugin': '^11.0.0',
+      'eslint-config-next': '>=14.0.0',
     },
   },
   {
     name: Plugin.Jest,
     frameworkPackages: ['jest'],
     eslintPlugins: {
-      'eslint-plugin-jest': '>=27.0.0 <29.0.0',
+      'eslint-plugin-jest': '>=29.0.0 <30.0.0',
     },
   },
   {
@@ -77,28 +70,28 @@ const PLUGINS = [
       '@testing-library/react',
     ],
     eslintPlugins: {
-      'eslint-plugin-testing-library': '^6.0.0',
+      'eslint-plugin-testing-library': '>=7.0.0 <8.0.0',
     },
   },
   {
     name: Plugin.Cypress,
     frameworkPackages: ['cypress'],
     eslintPlugins: {
-      'eslint-plugin-cypress': '^2.0.0',
+      'eslint-plugin-cypress': '>=4.0.0 <6.0.0',
     },
   },
   {
     name: Plugin.Playwright,
     frameworkPackages: ['@playwright/test'],
     eslintPlugins: {
-      'eslint-plugin-playwright': '>=0.17.0 <2.0.0',
+      'eslint-plugin-playwright': '>=2.0.0 <3.0.0',
     },
   },
   {
     name: Plugin.Storybook,
     frameworkPackages: ['storybook', '@storybook/react'],
     eslintPlugins: {
-      'eslint-plugin-storybook': '>=0.6.0 <1.0.0',
+      'eslint-plugin-storybook': '>=9.0.0 <10.0.0',
     },
   },
 ];

--- a/src/lib/options.ts
+++ b/src/lib/options.ts
@@ -40,16 +40,6 @@ export const BROWSER_LIBRARIES = ['next', 'react', 'preact', 'svelte', 'vue'];
 const PLUGINS = [
   {
     name: Plugin.CircuitUI,
-    frameworkPackages: ['@sumup/circuit-ui', '@sumup/design-tokens'],
-    eslintPlugins: {
-      '@sumup/eslint-plugin-circuit-ui': '>=3.0.0 <5.0.0',
-    },
-    stylelintPlugins: {
-      '@sumup/stylelint-plugin-circuit-ui': '>=1.0.0 <3.0.0',
-    },
-  },
-  {
-    name: Plugin.CircuitUIOSS,
     frameworkPackages: ['@sumup-oss/circuit-ui', '@sumup-oss/design-tokens'],
     eslintPlugins: {
       '@sumup-oss/eslint-plugin-circuit-ui': '>=5.0.0 <6.0.0',

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -34,7 +34,6 @@ export enum Framework {
 
 export enum Plugin {
   CircuitUI = 'Circuit UI',
-  CircuitUIOSS = 'Circuit UI (OSS scope)',
   Cypress = 'Cypress',
   Emotion = 'Emotion',
   Jest = 'Jest',


### PR DESCRIPTION
## Purpose

Review and update the supported ESLint and Stylelint plugin version ranges.

## Approach and changes

- Remove support for old Circuit UI package scope (`@sumup/*`)
- Remove support for ESLint plugins that don't support the new flat config
- Add support for latest plugin versions

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
