### PR TITLE
Fix init options

### DIFF
--- a/.changeset/proud-poets-wash.md
+++ b/.changeset/proud-poets-wash.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/foundry": patch
+---
+
+Fixed reading the options when running `foundry init`.

--- a/README.md
+++ b/README.md
@@ -43,12 +43,10 @@ Foundry will launch an interactive prompt to ask you questions about your projec
 Alternatively, you can pass your answers to the `init` command directly as flags. This is useful for environments such as CI where interactive prompts cannot be used. Here is an overview of all available options (you can view this help menu by running `npx foundry init --help`):
 
 ```sh
-  -o, --openSource  Whether the project is open-source                 [boolean]
-  -c, --configDir   The directory to write configs to    [string] [default: "."]
-      --overwrite   Whether to overwrite existing config files
-                                                      [boolean] [default: false]
-      --version     Show version number                                [boolean]
-      --help        Show this help menu                                [boolean]
+  --configDir  The directory to write configs to         [string] [default: "."]
+  --overwrite  Whether to overwrite existing configs  [boolean] [default: false]
+  --version    Show version number                                     [boolean]
+  --help       Show this help menu                                     [boolean]
 ```
 
 ## Scripts

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,42 @@
       },
       "engines": {
         "node": "^20.19 || >=22"
+      },
+      "peerDependencies": {
+        "@next/eslint-plugin-next": ">=15.0.0",
+        "@sumup-oss/eslint-plugin-circuit-ui": ">=7.0.0 <8.0.0",
+        "@sumup-oss/stylelint-plugin-circuit-ui": ">=3.0.0 <5.0.0",
+        "eslint-plugin-cypress": ">=4.0.0 <6.0.0",
+        "eslint-plugin-jest": ">=29.0.0 <30.0.0",
+        "eslint-plugin-playwright": ">=2.0.0 <3.0.0",
+        "eslint-plugin-storybook": ">=9.0.0 <10.0.0",
+        "eslint-plugin-testing-library": ">=7.0.0 <8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@next/eslint-plugin-next": {
+          "optional": true
+        },
+        "@sumup-oss/eslint-plugin-circuit-ui": {
+          "optional": true
+        },
+        "@sumup-oss/stylelint-plugin-circuit-ui": {
+          "optional": true
+        },
+        "eslint-plugin-cypress": {
+          "optional": true
+        },
+        "eslint-plugin-jest": {
+          "optional": true
+        },
+        "eslint-plugin-playwright": {
+          "optional": true
+        },
+        "eslint-plugin-storybook": {
+          "optional": true
+        },
+        "eslint-plugin-testing-library": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,38 +65,14 @@
         "node": "^20.19 || >=22"
       },
       "peerDependencies": {
-        "@next/eslint-plugin-next": ">=15.0.0",
-        "@sumup-oss/eslint-plugin-circuit-ui": ">=7.0.0 <8.0.0",
         "@sumup-oss/stylelint-plugin-circuit-ui": ">=3.0.0 <5.0.0",
-        "eslint-plugin-cypress": ">=4.0.0 <6.0.0",
-        "eslint-plugin-jest": ">=29.0.0 <30.0.0",
-        "eslint-plugin-playwright": ">=2.0.0 <3.0.0",
-        "eslint-plugin-storybook": ">=9.0.0 <10.0.0",
-        "eslint-plugin-testing-library": ">=7.0.0 <8.0.0"
+        "eslint-plugin-react": "^7.35.0"
       },
       "peerDependenciesMeta": {
-        "@next/eslint-plugin-next": {
-          "optional": true
-        },
-        "@sumup-oss/eslint-plugin-circuit-ui": {
-          "optional": true
-        },
         "@sumup-oss/stylelint-plugin-circuit-ui": {
           "optional": true
         },
-        "eslint-plugin-cypress": {
-          "optional": true
-        },
-        "eslint-plugin-jest": {
-          "optional": true
-        },
-        "eslint-plugin-playwright": {
-          "optional": true
-        },
-        "eslint-plugin-storybook": {
-          "optional": true
-        },
-        "eslint-plugin-testing-library": {
+        "eslint-plugin-react": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -118,5 +118,41 @@
     "rimraf": "^6.0.1",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"
+  },
+  "peerDependencies": {
+    "@next/eslint-plugin-next": ">=15.0.0",
+    "@sumup-oss/eslint-plugin-circuit-ui": ">=7.0.0 <8.0.0",
+    "@sumup-oss/stylelint-plugin-circuit-ui": ">=3.0.0 <5.0.0",
+    "eslint-plugin-cypress": ">=4.0.0 <6.0.0",
+    "eslint-plugin-jest": ">=29.0.0 <30.0.0",
+    "eslint-plugin-playwright": ">=2.0.0 <3.0.0",
+    "eslint-plugin-storybook": ">=9.0.0 <10.0.0",
+    "eslint-plugin-testing-library": ">=7.0.0 <8.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@next/eslint-plugin-next": {
+      "optional": true
+    },
+    "@sumup-oss/eslint-plugin-circuit-ui": {
+      "optional": true
+    },
+    "@sumup-oss/stylelint-plugin-circuit-ui": {
+      "optional": true
+    },
+    "eslint-plugin-cypress": {
+      "optional": true
+    },
+    "eslint-plugin-jest": {
+      "optional": true
+    },
+    "eslint-plugin-playwright": {
+      "optional": true
+    },
+    "eslint-plugin-storybook": {
+      "optional": true
+    },
+    "eslint-plugin-testing-library": {
+      "optional": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -120,38 +120,14 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "@next/eslint-plugin-next": ">=15.0.0",
-    "@sumup-oss/eslint-plugin-circuit-ui": ">=7.0.0 <8.0.0",
     "@sumup-oss/stylelint-plugin-circuit-ui": ">=3.0.0 <5.0.0",
-    "eslint-plugin-cypress": ">=4.0.0 <6.0.0",
-    "eslint-plugin-jest": ">=29.0.0 <30.0.0",
-    "eslint-plugin-playwright": ">=2.0.0 <3.0.0",
-    "eslint-plugin-storybook": ">=9.0.0 <10.0.0",
-    "eslint-plugin-testing-library": ">=7.0.0 <8.0.0"
+    "eslint-plugin-react": "^7.35.0"
   },
   "peerDependenciesMeta": {
-    "@next/eslint-plugin-next": {
-      "optional": true
-    },
-    "@sumup-oss/eslint-plugin-circuit-ui": {
-      "optional": true
-    },
     "@sumup-oss/stylelint-plugin-circuit-ui": {
       "optional": true
     },
-    "eslint-plugin-cypress": {
-      "optional": true
-    },
-    "eslint-plugin-jest": {
-      "optional": true
-    },
-    "eslint-plugin-playwright": {
-      "optional": true
-    },
-    "eslint-plugin-storybook": {
-      "optional": true
-    },
-    "eslint-plugin-testing-library": {
+    "eslint-plugin-react": {
       "optional": true
     }
   }

--- a/src/cli/defaults.ts
+++ b/src/cli/defaults.ts
@@ -13,10 +13,9 @@
  * limitations under the License.
  */
 
-import type { InitOptions } from '../types/shared.js';
+import type { InitArgs } from '../types/shared.js';
 
-export const DEFAULT_OPTIONS: InitOptions = {
+export const DEFAULT_ARGS: InitArgs = {
   configDir: '.',
-  openSource: false,
   overwrite: false,
 };

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
 import { debug } from './debug.js';
-import { DEFAULT_OPTIONS } from './defaults.js';
+import { DEFAULT_ARGS } from './defaults.js';
 import { type InitParams, init } from './init.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions
@@ -28,21 +28,15 @@ yargs(hideBin(process.argv))
     'init',
     "Initialize Foundry's tools in your project",
     {
-      openSource: {
-        alias: 'o',
-        desc: 'Whether the project is open-source',
-        type: 'boolean',
-      },
       configDir: {
-        alias: 'c',
         desc: 'The directory to write configs to',
         type: 'string',
-        default: DEFAULT_OPTIONS.configDir,
+        default: DEFAULT_ARGS.configDir,
       },
       overwrite: {
-        desc: 'Whether to overwrite existing config files',
+        desc: 'Whether to overwrite existing configs',
         type: 'boolean',
-        default: DEFAULT_OPTIONS.overwrite,
+        default: DEFAULT_ARGS.overwrite,
       },
     },
     execute('init'),

--- a/src/configs/eslint/index.spec.ts
+++ b/src/configs/eslint/index.spec.ts
@@ -27,7 +27,7 @@ import { files } from './index.js';
 describe('eslint', () => {
   describe('files', () => {
     it('should match the snapshot for basic options', () => {
-      const options = { configDir: '.' };
+      const options = {};
       const actual = files(options);
       expect(actual).toMatchSnapshot();
     });

--- a/src/configs/eslint/index.ts
+++ b/src/configs/eslint/index.ts
@@ -19,8 +19,8 @@ import {
   Environment,
   type File,
   Framework,
-  type InitOptions,
   Language,
+  type Options,
   Plugin,
 } from '../../types/shared.js';
 
@@ -36,7 +36,7 @@ const testPlugins = [
   Plugin.TestingLibrary,
 ];
 
-export function files(options: InitOptions): File[] {
+export function files(options: Options): File[] {
   const configs = ['configs.ignores', 'configs.javascript'];
   const imports = [];
 

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -51,9 +51,9 @@ export interface Options {
   openSource?: boolean;
 }
 
-export interface InitOptions extends Options {
+export interface InitArgs {
   configDir: string;
-  overwrite?: boolean;
+  overwrite: boolean;
 }
 
 export type File = {
@@ -63,5 +63,5 @@ export type File = {
 };
 
 export interface ToolOptions {
-  files?: (options: InitOptions) => File[];
+  files?: (options: Options) => File[];
 }


### PR DESCRIPTION
## Purpose

Due to loose types, an incomplete options object is passed to the tools to initialize their config files, causing the ESLint config to miss relevant plugins.

## Approach and changes

- Tighten up the types
- Pass the right options object to the tool files functions
- Remove the `openSource` CLI flag

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
