### PR TITLE
Drop support for Node <24

### DIFF
--- a/.changeset/giant-plants-relate.md
+++ b/.changeset/giant-plants-relate.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/foundry": major
+---
+
+Dropped support for Node <24.

--- a/package.json
+++ b/package.json
@@ -63,11 +63,10 @@
     "release": "changeset publish"
   },
   "engines": {
-    "node": "^20.19 || >=22"
+    "node": ">=24"
   },
   "browserslist": [
-    "node 20.19",
-    "node 22"
+    "node 24"
   ],
   "dependencies": {
     "@biomejs/biome": "2.2.4",


### PR DESCRIPTION
## Purpose

Node 24 is current active LTS ([ref](https://nodejs.org/en/about/previous-releases)).

## Approach and changes

- Raise the minimum Node version to 24+.

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
- [x] Unit and integration tests
